### PR TITLE
Rename artifactId, use renamed deployer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<properties>
 		<spring-cloud-dataflow.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-dataflow.version>
-		<spring-cloud-cloudfoundry-deployer.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-cloudfoundry-deployer.version>
+		<spring-cloud-deployer-cloudfoundry.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
 		<reactor.version>2.5.0.BUILD-SNAPSHOT</reactor.version>
 	</properties>
 

--- a/spring-cloud-starter-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-starter-dataflow-server-cloudfoundry/pom.xml
@@ -21,9 +21,9 @@
 			<version>${spring-cloud-dataflow.version}</version>
 		</dependency>
 		<dependency>
-			<artifactId>spring-cloud-cloudfoundry-deployer</artifactId>
+			<artifactId>spring-cloud-deployer-cloudfoundry</artifactId>
 			<groupId>org.springframework.cloud</groupId>
-			<version>${spring-cloud-cloudfoundry-deployer.version}</version>
+			<version>${spring-cloud-deployer-cloudfoundry.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-dataflow-admin-cloudfoundry#86

Requires https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry/pull/23