### PR TITLE
Add OAUTH security configurations

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -137,6 +137,12 @@ server-unknown:>dataflow config server http://dataflow-server.cfapps.io
 Successfully targeted http://dataflow-server.cfapps.io
 dataflow:>
 ```
+== Security
+
+By default, the Data Flow server is unsecured and runs on an unencrypted HTTP connection. You can secure your REST endpoints, 
+as well as the Data Flow Dashboard by enabling HTTPS and requiring clients to authenticate. More details about securing the 
+REST endpoints and configuring to authenticate against an OAUTH backend (_i.e: UAA/SSO running on Cloud Foundry_), please 
+review the security section from the core http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/getting-started-security.html[reference guide]. The security configurations can be configured in `dataflow-server.yml` or passed as environment variables through `cf set-env` commands. 
 
 == Configuration Reference
 

--- a/spring-cloud-dataflow-server-cloudfoundry/src/main/resources/dataflow-server.yml
+++ b/spring-cloud-dataflow-server-cloudfoundry/src/main/resources/dataflow-server.yml
@@ -22,6 +22,14 @@ cloudfoundry:
 security:
   basic:
     enabled: false
+#  oauth2:
+#    client:
+#      client-id: myclient
+#      client-secret: mysecret
+#      access-token-uri: http://127.0.0.1:9999/oauth/token
+#      user-authorization-uri: http://127.0.0.1:9999/oauth/authorize
+#    resource:
+#      user-info-uri: http://127.0.0.1:9999/me
 
 spring:
   application:


### PR DESCRIPTION
- add security configuration to `dataflow-server.yml`
- update docs to include security section and the link to core docs

Resolves spring-cloud/spring-cloud-dataflow-server-cloudfoundry#112