### PR TITLE
Force dependency on reactor, with controlled version Switch back to latest deployer snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dataflow-parent</artifactId>
-		<version>1.0.0.RC1</version>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
 	<properties>
-		<spring-cloud-dataflow.version>1.0.0.RC1</spring-cloud-dataflow.version>
-		<spring-cloud-deployer-cloudfoundry.version>1.0.0.M2</spring-cloud-deployer-cloudfoundry.version>
+		<spring-cloud-dataflow.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-dataflow.version>
+		<spring-cloud-deployer-cloudfoundry.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
 		<reactor.version>2.5.0.M3</reactor.version>
 	</properties>
 

--- a/spring-cloud-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry/pom.xml
@@ -29,6 +29,12 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-core</artifactId>
+			<version>${reactor.version}</version>
+		</dependency>
+
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-starter-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-starter-dataflow-server-cloudfoundry/pom.xml
@@ -32,5 +32,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-core</artifactId>
+			<version>${reactor.version}</version>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-dataflow-server-cloudfoundry#133