### PR TITLE
Upgrade to latest deployer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 
 	<properties>
 		<spring-cloud-dataflow.version>1.0.0.RELEASE</spring-cloud-dataflow.version>
-		<spring-cloud-deployer-cloudfoundry.version>1.0.0.M4</spring-cloud-deployer-cloudfoundry.version>
-		<reactor.version>2.5.0.M3</reactor.version>
+		<spring-cloud-deployer-cloudfoundry.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
+		<reactor.version>3.0.0.RC1</reactor.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry/pom.xml
@@ -18,23 +18,11 @@
 			<artifactId>spring-cloud-starter-dataflow-server-cloudfoundry</artifactId>
 			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
-		<!-- Test dependencies -->
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
 			<version>${reactor.version}</version>
 		</dependency>
-
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-starter-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-starter-dataflow-server-cloudfoundry/pom.xml
@@ -33,6 +33,11 @@
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
 			<version>${reactor.version}</version>


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-dataflow-server-cloudfoundry#145


For some reason, this put into light the fact that our
dependency to tomcat was somewhat broken. Fixed that in the starter.