### PR TITLE
Activated task functionality

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -30,6 +30,14 @@ For example when using link:https://run.pivotal.io/[Pivotal Web Services]:
 cf create-service cloudamqp lemur rabbit
 ```
 
+=== Provision a MySQL service instance on Cloud Foundry.
+Use `cf marketplace` to discover which plans are available to you, depending on the details of your Cloud Foundry setup.
+For example when using link:https://run.pivotal.io/[Pivotal Web Services]:
+
+```
+cf create-service p_mysql 100mb my_mysql
+```
+
 === Download the Spring Cloud Data Flow Server and Shell apps:
 
 [subs=attributes]

--- a/spring-cloud-dataflow-server-cloudfoundry/src/main/resources/dataflow-server.yml
+++ b/spring-cloud-dataflow-server-cloudfoundry/src/main/resources/dataflow-server.yml
@@ -39,7 +39,16 @@ spring:
       uri: http://localhost:8888
     dataflow:
       features:
-        tasksEnabled: false
+        tasksEnabled: true
+    deployer:
+      cloudfoundry:
+        taskTimeout: 360
+#  datasource:
+#    url: jdbc:mysql://p-mysql-proxy.run.pivotal.io:3306/cf_9c2e36a7_0c81_4887_930b_8c3444ae6834?user=JwEHRDLH32w0lMpj\u0026password=vl2ryUqH65j5wHBH
+#    username: JwEHRDLH32w0lMpj
+#    password: vl2ryUqH65j5wHBH
+#    driverClassName: com.mysql.jdbc.Driver
+
 #
 # If you prefer to use Eureka to locate the Config Server, you can do that by setting
 # spring.cloud.config.discovery.enabled=true (default "false"). The net result of that is 


### PR DESCRIPTION
This commit enables task functionality for Spring Cloud Data Flow on
CloudFoundry.  CloudFoundry 1.7.12+ is required for task support.

Resolves spring-cloud/spring-cloud-dataflow-server-cloudfoundry#43

Depends on spring-cloud/spring-cloud-deployer-cloudfoundry#63