### PR TITLE
Add experimental feature property to enable/disable task feature

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -162,8 +162,11 @@ Tasks are enabled as `experimental` feature in Spring Cloud Data Flow Cloud Foun
 can set the environment variable,
 
 ```
-export TASKS_ENABLED_AS_EXPERIMENTAL_FEATURE=true
+export SPRING_CLOUD_DATAFLOW_FEATURES_EXPERIMENTAL_TASKSENABLED=true
 ```
+
+or, as a command line argument when starting the data flow server `--spring.cloud.dataflow.features.experimental.tasksEnabled=true`
+
 === Running Spring Cloud Data Flow Shell locally
 
 Run the shell and optionally target the Admin application if not running on the same host (will typically be the case if

--- a/spring-cloud-dataflow-server-cloudfoundry/src/main/resources/dataflow-server.yml
+++ b/spring-cloud-dataflow-server-cloudfoundry/src/main/resources/dataflow-server.yml
@@ -37,10 +37,10 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
-#    dataflow:
-#      features:
-#        experimental:
-#          tasksEnabled: true
+    dataflow:
+      features:
+        experimental:
+          tasksEnabled: false
     deployer:
       cloudfoundry:
         taskTimeout: 360

--- a/spring-cloud-dataflow-server-cloudfoundry/src/main/resources/dataflow-server.yml
+++ b/spring-cloud-dataflow-server-cloudfoundry/src/main/resources/dataflow-server.yml
@@ -37,9 +37,10 @@ spring:
   cloud:
     config:
       uri: http://localhost:8888
-    dataflow:
-      features:
-        tasksEnabled: ${TASKS_ENABLED_AS_EXPERIMENTAL_FEATURE:false}
+#    dataflow:
+#      features:
+#        experimental:
+#          tasksEnabled: true
     deployer:
       cloudfoundry:
         taskTimeout: 360

--- a/spring-cloud-starter-dataflow-server-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundryEnvironmentPostProcessor.java
+++ b/spring-cloud-starter-dataflow-server-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundryEnvironmentPostProcessor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.cloudfoundry.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.cloud.dataflow.server.config.features.FeaturesProperties;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * An {@link EnvironmentPostProcessor} that sets the original task feature property based on the property
+ * 'spring.cloud.dataflow.features.experimental.tasksEnabled' value.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class CloudFoundryEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+	private static final String FEATURES_PREFIX = FeaturesProperties.FEATURES_PREFIX + ".";
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		Map<String, Object> propertiesToOverride = new HashMap<>();
+		String isTasksEnabled = environment.getProperty(FEATURES_PREFIX + "experimental.tasksEnabled");
+		propertiesToOverride.put(FEATURES_PREFIX + FeaturesProperties.TASKS_ENABLED, Boolean.valueOf(isTasksEnabled));
+		environment.getPropertySources().addFirst(new MapPropertySource("CFDataflowServerProperties", propertiesToOverride));
+	}
+}

--- a/spring-cloud-starter-dataflow-server-cloudfoundry/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-dataflow-server-cloudfoundry/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,4 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  org.springframework.cloud.dataflow.server.cloudfoundry.config.CloudFoundryEnvironmentPostProcessor
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   org.springframework.cloud.dataflow.server.cloudfoundry.config.CloudFoundryDataFlowServerConfiguration


### PR DESCRIPTION
 - The property `spring.cloud.dataflow.features.experimental.tasksEnabled` will enable/disable the task feature by
setting the original `spring.cloud.dataflow.features.tasksEnabled` property with highest precedence.