### PR TITLE
Add task orchestration docs

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
@@ -74,7 +74,7 @@
 									<doctype>book</doctype>
 									<attributes>
 										<docinfo>true</docinfo>
-										<omit-tasks-docs>true</omit-tasks-docs>
+										<omit-tasks-docs>false</omit-tasks-docs>
 										<dataflow-project-version>${spring-cloud-dataflow.version}</dataflow-project-version>
 										<project-version>${project.version}</project-version>
 										<project-artifactId>${project.artifactId}</project-artifactId>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
@@ -74,7 +74,6 @@
 									<doctype>book</doctype>
 									<attributes>
 										<docinfo>true</docinfo>
-										<omit-tasks-docs>false</omit-tasks-docs>
 										<dataflow-project-version>${spring-cloud-dataflow.version}</dataflow-project-version>
 										<project-version>${project.version}</project-version>
 										<project-artifactId>${project.artifactId}</project-artifactId>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/cf-tasks.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/cf-tasks.adoc
@@ -1,7 +1,7 @@
 [[tasks-on-cloudfoundry]]
 = Tasks on Cloud Foundry
 
-Spring Cloud Data Flow's task functionality exposes new, experimental, capabilities within
+Spring Cloud Data Flow's task functionality exposes new experimental capabilities within
 the Pivotal Cloud Foundry runtime. It's important to note that the current underlying PCF
 capabilities are considered experimental, and therefore this functionality within Spring
 Cloud Data Flow is also considered experimental.
@@ -18,7 +18,7 @@ around it within the CF ecosystem is not complete.  In order to interact with ta
 PCF command line interface (CLI), you need to install a plugin:
 link:https://github.com/cloudfoundry/v3-cli-plugin[v3-cli-plugin]. It's important to note
 that this plugin is only compatible with the PCF CLI version 6.17.0+5d0be0a-2016-04-15.
-You can read more about the functionality the plugin provides in it's README.
+You can read more about the functionality the plugin provides in its README.
 
 It's also important to note that there is no Apps Manager support for tasks as of this
 release. When running applications as tasks through Spring Cloud Data Flow, the only way
@@ -27,13 +27,13 @@ to view them within the context of CF is via the plugin mentioned above.
 == Running Task Applications
 
 Running a task application within Spring Cloud Data Flow goes through a slightly different
-lifecycle than running a stream application. Both applications need to be registered with
-the appropriate artifact coordinates. Both need a definition created via the SCDF DSL.
+lifecycle than running a stream application. Both types of applications need to be registered
+with the appropriate artifact coordinates. Both need a definition created via the SCDF DSL.
 However, that's where the similarities end.
 
 With stream based applications, you "deploy" them with the intent that they run until they
 are undeployed. A stream definition is only deployed once (it can be scaled, but only
-deployed as one instance of the stream as a whole). However, tasks are launched. A single
+deployed as one instance of the stream as a whole). However, tasks are _launched_. A single
 task definition can be launched many times. With each launch, they will start, execute,
 and shut down with PCF cleaning up the resources once the shutdown has occurred. The
 following sections outline the process of creating, launching, destroying, and viewing tasks.
@@ -41,9 +41,10 @@ following sections outline the process of creating, launching, destroying, and v
 === Create a Task
 
 Similar to streams, creating a task application is done via the SCDF DSL or through the
-dashboard. In order to create a task application, it is assumed that you've developed a
-task application and the maven coordinates are registered in SCDF. For more details on how to
-register task application, review link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/_the_lifecycle_of_a_task.html#_registering_a_task_application[register task applications]
+dashboard. To create a task definition in SCDF, you've to either develop a task
+application or use one of the out-of-the-box link:http://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[task app-starters].
+The maven coordinates of the task application should be registered in SCDF. For more
+details on how to register task applications, review <<_registering_a_task_application,register task applications>>
 section from the core docs.
 
 Let's see an example that uses the out-of-the-box `timestamp` task application.
@@ -54,12 +55,13 @@ dataflow:>task create --name foo --definition "timestamp"
 Created new task 'foo'
 ----
 
-NOTE: Tasks in SCDF do not require explicit deployment. They require launched and there are options to launch it a few
-different ways - refer to link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/spring-cloud-dataflow-launch-tasks-from-stream.html[this section] for more details.
+NOTE: Tasks in SCDF do not require explicit deployment. They are required to be launched
+and with that there are different ways to launch them - refer to <<spring-cloud-dataflow-launch-tasks-from-stream,this section>>
+for more details.
 
 === Launch a Task
 
-Unlike streams, tasks in SCDF requires explicit launch trigger or it can be manually kicked-off.
+Unlike streams, tasks in SCDF requires an explicit launch trigger or it can be manually kicked-off.
 
 [source]
 ----
@@ -71,7 +73,7 @@ Launched task 'foo'
 
 As previously mentioned, the v3-cli-plugin is the way to interact with tasks on PCF,
 including viewing the logs.  In order to view the logs as a task is executing use the
-following command where `<TASK_NAME>` is the name of the task you are executing:
+following command where `foo` is the name of the task you are executing:
 
 [source,bash]
 ----

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/cf-tasks.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/cf-tasks.adoc
@@ -1,0 +1,136 @@
+[[tasks-on-cloudfoundry]]
+= Tasks on Cloud Foundry
+
+Spring Cloud Data Flow's task functionality exposes new, experimental, capabilities within
+the Pivotal Cloud Foundry runtime. It's important to note that the current underlying PCF
+capabilities are considered experimental, and therefore this functionality within Spring
+Cloud Data Flow is also considered experimental.
+
+== Version Compatibility
+
+The task functionality depends on the latest versions of PCF for runtime support. This
+release requires PCF version 1.7.12 or higher to run tasks.
+
+== Tooling
+
+Because the task functionality is currently considered experimental within PCF, the tooling
+around it within the CF ecosystem is not complete.  In order to interact with tasks via the
+PCF command line interface (CLI), you need to install a plugin:
+link:https://github.com/cloudfoundry/v3-cli-plugin[v3-cli-plugin]. It's important to note
+that this plugin is only compatible with the PCF CLI version 6.17.0+5d0be0a-2016-04-15.
+You can read more about the functionality the plugin provides in it's README.
+
+It's also important to note that there is no Apps Manager support for tasks as of this
+release. When running applications as tasks through Spring Cloud Data Flow, the only way
+to view them within the context of CF is via the plugin mentioned above.
+
+== Running Task Applications
+
+Running a task application within Spring Cloud Data Flow goes through a slightly different
+lifecycle than running a stream application. Both applications need to be registered with
+the appropriate artifact coordinates. Both need a definition created via the SCDF DSL.
+However, that's where the similarities end.
+
+With stream based applications, you "deploy" them with the intent that they run until they
+are undeployed. A stream definition is only deployed once (it can be scaled, but only
+deployed as one instance of the stream as a whole). However, tasks are launched. A single
+task definition can be launched many times. With each launch, they will start, execute,
+and shut down with PCF cleaning up the resources once the shutdown has occurred. The
+following sections outline the process of creating, launching, destroying, and viewing tasks.
+
+=== Create a Task
+
+Similar to streams, creating a task application is done via the SCDF DSL or through the
+dashboard. In order to create a task application, it is assumed that you've developed a
+task application and the maven coordinates are registered in SCDF. For more details on how to
+register task application, review link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/_the_lifecycle_of_a_task.html#_registering_a_task_application[register task applications]
+section from the core docs.
+
+Let's see an example that uses the out-of-the-box `timestamp` task application.
+
+[source]
+----
+dataflow:>task create --name foo --definition "timestamp"
+Created new task 'foo'
+----
+
+NOTE: Tasks in SCDF do not require explicit deployment. They require launched and there are options to launch it a few
+different ways - refer to link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/spring-cloud-dataflow-launch-tasks-from-stream.html[this section] for more details.
+
+=== Launch a Task
+
+Unlike streams, tasks in SCDF requires explicit launch trigger or it can be manually kicked-off.
+
+[source]
+----
+dataflow:>task launch foo
+Launched task 'foo'
+----
+
+=== View Task Logs
+
+As previously mentioned, the v3-cli-plugin is the way to interact with tasks on PCF,
+including viewing the logs.  In order to view the logs as a task is executing use the
+following command where `<TASK_NAME>` is the name of the task you are executing:
+
+[source,bash]
+----
+cf v3-logs foo
+Tailing logs for app foo...
+
+....
+....
+....
+....
+
+2016-08-19T09:44:49.11-0700 [APP/TASK/bar1/0]OUT 2016-08-19 16:44:49.111  INFO 7 --- [           main] o.s.c.t.a.t.TimestampTaskApplication     : Started TimestampTaskApplication in 2.734 seconds (JVM running for 3.288)
+2016-08-19T09:44:49.13-0700 [APP/TASK/bar1/0]OUT Exit status 0
+2016-08-19T09:44:49.19-0700 [APP/TASK/bar1/0]OUT Destroying container
+2016-08-19T09:44:50.41-0700 [APP/TASK/bar1/0]OUT Successfully destroyed container
+----
+
+NOTE: Logs are only viewable through the v3-cli-plugin as the app is running.  Historic
+logs are not available.
+
+=== List Tasks
+
+Listing tasks is as simple as:
+
+[source]
+----
+dataflow:>task list
+╔══════════════════════╤═════════════════════════╤═══════════╗
+║      Task Name       │     Task Definition     │Task Status║
+╠══════════════════════╪═════════════════════════╪═══════════╣
+║foo                   │timestamp                │complete   ║
+╚══════════════════════╧═════════════════════════╧═══════════╝
+----
+
+=== List Task Executions
+
+If you'd like to view the execution details of the launched task, you could do the following.
+
+[source]
+----
+dataflow:>task execution list
+╔════════════════════════╤══╤═════════════════════════╤═════════════════════════╤════════╗
+║       Task Name        │ID│       Start Time        │        End Time         │  Exit  ║
+║                        │  │                         │                         │  Code  ║
+╠════════════════════════╪══╪═════════════════════════╪═════════════════════════╪════════╣
+║foo:cloud:              │1 │ Fri Aug 19 09:44:49 PDT │Fri Aug 19 09:44:49 PDT  │0       ║
+╚════════════════════════╧══╧═════════════════════════╧═════════════════════════╧════════╝
+----
+
+=== Destroy a Task
+
+Destroying the task application from SCDF removes the task definition from task repository.
+
+[source]
+----
+dataflow:>task destroy foo
+Destroyed task 'foo'
+dataflow:>task list
+╔═════════╤═══════════════╤═══════════╗
+║Task Name│Task Definition│Task Status║
+╚═════════╧═══════════════╧═══════════╝
+----

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -23,7 +23,7 @@ cf create-service rediscloud 30mb redis
 ```
 
 A redis instance is required for analytics apps, and would typically be bound to such apps when you create an analytics
-stream using the link:getting-started-service-binding-at-application-level[per-app-binding] feature.
+stream using the <<getting-started.adoc#getting-started-service-binding-at-application-level,per-app-binding>> feature.
 
 === Provision a Rabbit service instance on Cloud Foundry.
 Use `cf marketplace` to discover which plans are available to you, depending on the details of your Cloud Foundry setup.

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
@@ -33,7 +33,9 @@ include::getting-started.adoc[]
 
 include::{dataflow-asciidoc}/streams.adoc[]
 
+ifndef::omit-tasks-docs[]
 include::{dataflow-asciidoc}/tasks.adoc[]
+endif::omit-tasks-docs[]
 
 include::cf-tasks.adoc[]
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
@@ -1,5 +1,5 @@
 = Spring Cloud Data Flow Server for Cloud Foundry
-Sabby Anandan; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hillert; Mark Pollack; Thomas Risberg; Marius Bogoevici; Josh Long
+Sabby Anandan; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hillert; Mark Pollack; Thomas Risberg; Marius Bogoevici; Josh Long ; Michael Minella
 :doctype: book
 :toc:
 :toclevels: 4
@@ -32,6 +32,10 @@ include::{dataflow-asciidoc}/architecture.adoc[]
 include::getting-started.adoc[]
 
 include::{dataflow-asciidoc}/streams.adoc[]
+
+include::{dataflow-asciidoc}/tasks.adoc[]
+
+include::cf-tasks.adoc[]
 
 include::{dataflow-asciidoc}/dashboard.adoc[]
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/overview.adoc
@@ -16,3 +16,11 @@ There's a rich ecosystem of Spring Cloud Stream http://docs.spring.io/spring-clo
 
 Do you have a requirement to develop custom applications? No problem. Refer to this guide to create http://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle/#_creating_custom_artifacts[custom stream applications]. There're several https://github.com/spring-cloud/spring-cloud-stream-samples[samples] available for reference.
 
+[[spring-cloud-task-overview]]
+== Spring Cloud Task
+
+Spring Cloud Task makes it easy to create short-lived microservices. We provide capabilities that allow short-lived JVM processes to be executed on demand in a production environment.
+
+For more details about the core framework components and the supported features, please review Spring Cloud Task's http://docs.spring.io/spring-cloud-task/{sct-core-version}/reference/htmlsingle/[reference guide].
+
+There's a rich ecosystem of Spring Cloud Task http://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[Application-Starters] that can be used either as standalone data microservice applications or in Spring Cloud Data Flow. For convenience, the generated application-starters are available for use from http://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/[Maven Repo]. There are several https://github.com/spring-cloud/spring-cloud-task/tree/master/spring-cloud-task-samples[samples] available for reference.


### PR DESCRIPTION
This PR includes preliminary work of @mminella from [his branch](https://github.com/mminella/spring-cloud-dataflow-server-cloudfoundry/commit/8dbd9638f159bb614b91846a2b9bf287d1fc2c22).

- enable task docs (_in pom.xml_)
- add new file for "tasks on cf"
- adjust title for better continuity 

Resolves spring-cloud/spring-cloud-dataflow-server-cloudfoundry#157