### PR TITLE
[backport to 1.0.x] Fail the build if asciidoc include failed

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
@@ -360,6 +360,28 @@
 							</execution>
 						</executions>
 					</plugin>
+					<plugin>
+						<groupId>net.radai</groupId>
+						<artifactId>grep-maven-plugin</artifactId>
+						<version>1.0</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>grep</goal>
+								</goals>
+								<phase>test</phase>
+								<configuration>
+									<greps>
+										<grep>
+											<file>target/contents/reference/htmlsingle/index.html</file>
+											<grepPattern>Unresolved directive in .*\.adoc - include::</grepPattern>
+											<failIfFound>true</failIfFound>
+										</grep>
+									</greps>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/issues/193

One can easily test by
```
git revert 68aea18c1cbae4b33e0762d43cfdc82ff6200c43
```