### PR TITLE
Fixing mysql plan name on PWS

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -41,7 +41,7 @@ Use `cf marketplace` to discover which plans are available to you, depending on 
 For example when using link:https://run.pivotal.io/[Pivotal Web Services]:
 
 ```
-cf create-service p_mysql 100mb my_mysql
+cf create-service cleardb spark my_mysql
 ```
 
 An RDBMS is used to persist Data Flow state, such as stream definitions and deployment ids.


### PR DESCRIPTION
mysql plan name on docs was pointing to PCF broker name not cleardb on PWS