### PR TITLE
Add a flag to enable reactor enhanced stacktraces.

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundryDataFlowServerConfiguration.java
+++ b/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundryDataFlowServerConfiguration.java
@@ -17,6 +17,12 @@
 package org.springframework.cloud.dataflow.server.cloudfoundry.config;
 
 import java.io.File;
+import java.util.function.Function;
+
+import javax.annotation.PostConstruct;
+
+import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Mono;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.dataflow.server.cloudfoundry.resource.LRUCleaningResourceLoaderBeanPostProcessor;
@@ -59,6 +65,13 @@ public class CloudFoundryDataFlowServerConfiguration {
 		File repositoryCache = new File(mavenProperties.getLocalRepository());
 		float fRatio = serverConfiguration.getFreeDiskSpacePercentage() / 100F;
 		return new LRUCleaningResourceLoaderBeanPostProcessor(fRatio, repositoryCache);
+	}
+
+	@PostConstruct
+	public void afterPropertiesSet() {
+		if (cloudFoundryServerConfigurationProperties().isDebugReactor()) {
+			Hooks.onOperator(op -> op.operatorStacktrace());
+		}
 	}
 
 }

--- a/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundryServerConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundryServerConfigurationProperties.java
@@ -45,4 +45,17 @@ public class CloudFoundryServerConfigurationProperties {
 	public void setFreeDiskSpacePercentage(int freeDiskSpacePercentage) {
 		this.freeDiskSpacePercentage = freeDiskSpacePercentage;
 	}
+
+	/**
+	 * Whether to turn on reactor style stacktraces.
+	 */
+	public boolean debugReactor = false;
+
+	public boolean isDebugReactor() {
+		return debugReactor;
+	}
+
+	public void setDebugReactor(boolean debugReactor) {
+		this.debugReactor = debugReactor;
+	}
 }

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
@@ -379,7 +379,7 @@
 								<configuration>
 									<greps>
 										<grep>
-											<file>target/contents/reference/htmlsingle/index.html</file>
+											<file>target/generated-docs/index.html</file>
 											<grepPattern>Unresolved directive in .*\.adoc - include::</grepPattern>
 											<failIfFound>true</failIfFound>
 										</grep>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -410,6 +410,25 @@ as part of an individual deployment request prefixed by the `app.<name of applic
 
 will deploy the time source with 2048MB of memory, while the log sink will use the default 1024MB.
 
+=== Understanding what's going on
+If you want to get better insights into what is happening when your streams and tasks are being deployed, you may want
+to turn on the following features:
+
+* Reactor "stacktraces", showing which operators were involved before an error occurred. This is helpful as the deployer
+relies on project reactor and regular stacktraces may not always allow understanding the flow before an error happened.
+Note that this comes with a performance penalty, so is disabled by default.
++
+```
+spring.cloud.dataflow.server.cloudfoundry.debugReactor = true
+```
+* Deployer and Cloud Foundry client library request/response logs. This allows seeing detailed conversation between
+the Data Flow server and the Cloud Foundry Cloud Controller.
++
+```
+logging.level.cloudfoundry-client = DEBUG
+
+```
+
 === Using Spring Cloud Config Server
 Spring Cloud Config Server can be used to centralize configuration properties for Spring Boot applications. Likewise,
 both Spring Cloud Data Flow and the applications orchestrated using Spring Cloud Data Flow can be integrated with


### PR DESCRIPTION
Document turning on client request/response logs

Fixes https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/issues/253
Fixes https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/issues/270