### PR TITLE
Update SNAPSHOT versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dataflow-parent</artifactId>
-		<version>1.2.0.M2</version>
+		<version>1.2.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
 	<properties>
-		<spring-cloud-dataflow.version>1.2.0.M2</spring-cloud-dataflow.version>
-		<spring-cloud-deployer-cloudfoundry.version>1.2.0.M1</spring-cloud-deployer-cloudfoundry.version>
+		<spring-cloud-dataflow.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-dataflow.version>
+		<spring-cloud-deployer-cloudfoundry.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
 		<reactor.version>3.0.5.RELEASE</reactor.version>
 	</properties>
 


### PR DESCRIPTION
- update deployer/dataflow core versions to use 1.2.0.BUILD-SNAPSHOT
  - update parent dataflow to use 1.2.0.BUILD-SNAPSHOT

Resolves #285