### PR TITLE
Add version + copyright to html5 docs

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index-docinfo.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index-docinfo.xml
@@ -1,7 +1,7 @@
 <productname>Spring Cloud Data Flow Server for Cloud Foundry</productname>
 <releaseinfo>{project-version}</releaseinfo>
 <copyright>
-	<year>2013-2016</year>
+	<year>2013-2017</year>
 	<holder>Pivotal Software, Inc.</holder>
 </copyright>
 <legalnotice>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
@@ -10,6 +10,21 @@ Sabby Anandan; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hiller
 
 :spring-cloud-stream-docs: http://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/index.html
 :github-code: https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry
+
+
+ifdef::backend-html5[]
+
+Version {project-version}
+
+(C) 2012-2017 Pivotal Software, Inc.
+
+_Copies of this document may be made for your own use and for distribution to
+others, provided that you do not charge any fee for such copies and further
+provided that each copy contains this Copyright Notice, whether distributed in
+print or electronically._
+
+endif::backend-html5[]
+
 // ======================================================================================
 
 [[overview]]


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/issues/317

See my comments on the core PR before merging this copy/paste, some may apply