### PR TITLE
Adapt reference guide to new TOC experience

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-dataflow-parent</artifactId>
-		<version>1.2.2.RELEASE</version>
+		<version>1.2.3.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
 	<properties>
-		<spring-cloud-dataflow.version>1.2.2.RELEASE</spring-cloud-dataflow.version>
+		<spring-cloud-dataflow.version>1.2.3.BUILD-SNAPSHOT</spring-cloud-dataflow.version>
 		<spring-cloud-deployer-cloudfoundry.version>1.2.1.RELEASE</spring-cloud-deployer-cloudfoundry.version>
 		<spring-cloud-deployer-spi.version>1.2.1.RELEASE</spring-cloud-deployer-spi.version>
 		<reactor.version>3.0.7.RELEASE</reactor.version>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/appendix.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/appendix.adoc
@@ -1,5 +1,17 @@
 [[appendix]]
 = Appendices
 
+[partintro]
+--
+Having trouble with Spring Cloud Data Flow, We'd like to help!
+
+* Ask a question - we monitor http://stackoverflow.com[stackoverflow.com] for questions
+  tagged with http://stackoverflow.com/tags/spring-cloud-dataflow[`spring-cloud-dataflow`].
+* Report bugs with Spring Cloud Data Flow at https://github.com/spring-cloud/spring-cloud-dataflow/issues.
+* Report bugs with Spring Cloud Data Flow for Cloud Foundry at https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/issues.
+--
+
+include::{dataflow-asciidoc}/appendix-dataflow-template.adoc[]
 include::{dataflow-asciidoc}/appendix-migration-guide.adoc[]
-include::building.adoc[]
+include::{dataflow-asciidoc}/appendix-building.adoc[]
+include::{dataflow-asciidoc}/appendix-contributing.adoc[]

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/docinfo.html
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/docinfo.html
@@ -1,0 +1,68 @@
+<!-- Generate a nice TOC -->
+<script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
+<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tocify/1.9.0/javascripts/jquery.tocify.min.js"></script>
+<!-- We do not need the tocify CSS because the asciidoc CSS already provides most of what we neeed -->
+
+<style>
+.tocify-header {
+    font-style: italic;
+}
+.tocify-subheader {
+    font-style: normal;
+}
+.tocify ul {
+    margin: 0;
+ }
+.tocify-focus {
+    color: #7a2518; 
+    background-color: rgba(0, 0, 0, 0.1);
+}
+.tocify-focus > a {
+    color: #7a2518; 
+}
+</style>
+
+<script type="text/javascript">
+    $(function () {
+        // Add a new container for the tocify toc into the existing toc so we can re-use its
+        // styling
+        $("#toc").append("<div id='generated-toc'></div>");
+        $("#generated-toc").tocify({
+            extendPage: false,
+            context: "#content",
+            highlightOnScroll: false,
+            hideEffect: "slideUp",
+            // Use the IDs that asciidoc already provides so that TOC links and intra-document
+            // links are the same. Anything else might confuse users when they create bookmarks.
+            hashGenerator: function(text, element) {
+                return $(element).attr("id");
+            },
+            // Smooth scrolling doesn't work properly if we use the asciidoc IDs
+            smoothScroll: false,
+            // Set to 'none' to use the tocify classes
+            theme: "none",
+            // Handle book (may contain h1) and article (only h2 deeper)
+            selectors: $( "#content" ).has( "h1" ).size() > 0 ? "h1,h2,h3,h4,h5" : "h2,h3,h4,h5",
+            ignoreSelector: ".discrete"
+        });
+        // Switch between static asciidoc toc and dynamic tocify toc based on browser size
+        // This is set to match the media selectors in the asciidoc CSS
+        // Without this, we keep the dynamic toc even if it is moved from the side to preamble
+        // position which will cause odd scrolling behavior
+        var handleTocOnResize = function() {
+            if ($(document).width() < 768) {
+                $("#generated-toc").hide();
+                $(".sectlevel0").show();
+                $(".sectlevel1").show();
+            }
+            else {
+                $("#generated-toc").show();
+                $(".sectlevel0").hide();
+                $(".sectlevel1").hide();
+            }
+        }
+        $(window).resize(handleTocOnResize);
+        handleTocOnResize();
+    });
+</script>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
@@ -1,16 +1,16 @@
 = Spring Cloud Data Flow Server for Cloud Foundry
 Sabby Anandan; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hillert; Mark Pollack; Thomas Risberg; Marius Bogoevici; Josh Long ; Michael Minella; David Turanski
 :doctype: book
-:toc:
+:toc: left
 :toclevels: 4
 :source-highlighter: prettify
 :numbered:
 :icons: font
 :hide-uri-scheme:
+:docinfo: shared
 
 :spring-cloud-stream-docs: http://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/index.html
 :github-code: https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry
-
 
 ifdef::backend-html5[]
 
@@ -27,30 +27,20 @@ endif::backend-html5[]
 
 // ======================================================================================
 
-[[overview]]
-= Spring Cloud Data Flow for Cloud Foundry
-
-This project provides support for orchestrating the deployment of Spring Cloud Stream applications to Cloud Foundry.
-
-include::overview.adoc[]
-
-include::{dataflow-asciidoc}/architecture.adoc[]
-
 include::getting-started.adoc[]
 
+include::{dataflow-asciidoc}/applications.adoc[]
+include::{dataflow-asciidoc}/architecture.adoc[]
 include::{dataflow-asciidoc}/configuration.adoc[]
 
+include::{dataflow-asciidoc}/shell.adoc[]
 include::{dataflow-asciidoc}/streams.adoc[]
-
 ifndef::omit-tasks-docs[]
 include::{dataflow-asciidoc}/tasks.adoc[]
-endif::omit-tasks-docs[]
-
 include::cf-tasks.adoc[]
-
+endif::omit-tasks-docs[]
 include::{dataflow-asciidoc}/dashboard.adoc[]
-
-include::{dataflow-asciidoc}/howto.adoc[]
+include::{dataflow-asciidoc}/api-guide.adoc[]
 
 include::appendix.adoc[]
 


### PR DESCRIPTION
- Bump the local-server version to 1.2.3.BS (version pulled in the docs for includes)
- Add new TOC experience related infrastructure
- Reorder sections to adapt to general core reference guide for consistency
- Fix appendices section

Resolves spring-cloud/spring-cloud-dataflow-server-cloudfoundry#342