### PR TITLE
Use a link instead of an include for REST docs.

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
@@ -36,6 +36,7 @@
 						<executions>
 							<execution>
 								<id>set-all</id>
+								<phase>initialize</phase>
 								<goals>
 									<goal>set-version</goal>
 								</goals>
@@ -124,7 +125,7 @@
 							</execution>
 							<execution>
 								<id>generate-html5</id>
-								<phase>prepare-package</phase>
+								<phase>generate-resources</phase>
 								<goals>
 									<goal>process-asciidoc</goal>
 								</goals>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/api-guide-link.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/api-guide-link.adoc
@@ -1,0 +1,9 @@
+// The API Guide adoc source file residing in SCDF core can't be included here, because it depends on generated
+// REST Docs snippets that aren't versionned (and are heavyweight to regenerate for each flavor). Hence, we do a
+// simple link to the correct SCDF core version:
+:spring-cloud-dataflow-docs-rest: http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/index.html#api-guide
+
+[[api-guide]]
+= REST API Guide
+
+You can find the documentation about the Data Flow REST API in the {spring-cloud-dataflow-docs-rest}[core documentation].

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
@@ -30,17 +30,22 @@ endif::backend-html5[]
 include::getting-started.adoc[]
 
 include::{dataflow-asciidoc}/applications.adoc[]
+
 include::{dataflow-asciidoc}/architecture.adoc[]
+
 include::{dataflow-asciidoc}/configuration.adoc[]
 
 include::{dataflow-asciidoc}/shell.adoc[]
+
 include::{dataflow-asciidoc}/streams.adoc[]
-ifndef::omit-tasks-docs[]
+
 include::{dataflow-asciidoc}/tasks.adoc[]
+
 include::cf-tasks.adoc[]
-endif::omit-tasks-docs[]
+
 include::{dataflow-asciidoc}/dashboard.adoc[]
-include::{dataflow-asciidoc}/api-guide.adoc[]
+
+include::api-guide-link.adoc[]
 
 include::appendix.adoc[]
 


### PR DESCRIPTION
Also, fix out of order plugin executions in maven

Fixes #348