### PR TITLE
Document skipper + cf-server integration with an example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<spring-cloud-deployer-cloudfoundry.version>1.3.0.M4</spring-cloud-deployer-cloudfoundry.version>
 		<spring-cloud-deployer-spi.version>1.3.0.M2</spring-cloud-deployer-spi.version>
 		<spring-cloud-common-security-config.version>1.0.0.M1</spring-cloud-common-security-config.version>
+		<spring-cloud-skipper.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-skipper.version>
 		<reactor.version>3.0.7.RELEASE</reactor.version>
 	</properties>
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/pom.xml
@@ -93,10 +93,13 @@
 
 								<dataflow-project-version>${spring-cloud-dataflow.version}</dataflow-project-version>
 								<deployer-cloudfoundry-version>${spring-cloud-deployer-cloudfoundry.version}</deployer-cloudfoundry-version>
+								<skipper-version>${spring-cloud-skipper.version}</skipper-version>
 								<dataflow-version-type-lowercase>${dataflow-version-type-lowercase}</dataflow-version-type-lowercase>
+								<skipper-version-type-lowercase>${skipper-version-type-lowercase}</skipper-version-type-lowercase>
 								<dataflow-branch-or-tag>${dataflow-branch-or-tag}</dataflow-branch-or-tag>
 								<dataflow-asciidoc>https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/${dataflow-branch-or-tag}/spring-cloud-dataflow-docs/src/main/asciidoc</dataflow-asciidoc>
 								<deployer-branch-or-tag>${deployer-branch-or-tag}</deployer-branch-or-tag>
+								<skipper-branch-or-tag>${skipper-branch-or-tag}</skipper-branch-or-tag>
 
 								<!-- The following two are deps of this project and set automatically.-->
 								<!-- Others are loose dependencies, and current-SNAPSHOT typically make sense-->
@@ -338,9 +341,19 @@
 											<lowercase />
 										</stringutil>
 
+										<var name="skipper-version-type" value="${spring-cloud-skipper.version}" />
+										<propertyregex property="skipper-version-type" override="true" input="${skipper-version-type}" regexp=".*\.(.*)" replace="\1" />
+										<propertyregex property="skipper-version-type" override="true" input="${skipper-version-type}" regexp="(M)\d+" replace="MILESTONE" />
+										<propertyregex property="skipper-version-type" override="true" input="${skipper-version-type}" regexp="(RC)\d+" replace="MILESTONE" />
+										<propertyregex property="skipper-version-type" override="true" input="${skipper-version-type}" regexp="BUILD-(.*)" replace="SNAPSHOT" />
+										<stringutil string="${skipper-version-type}" property="skipper-version-type-lowercase">
+											<lowercase />
+										</stringutil>
+
 										<!-- This will use the vX.Y.Z tag for releases, using master for anything else (which is deemed ok, even for maintenance SNAPSHOT) -->
 										<propertyregex property="dataflow-branch-or-tag" override="true" input="${spring-cloud-dataflow.version}" regexp=".*\.(?:M\d+|RC\d+|RELEASE)" select="v\0" defaultValue="master" />
 										<propertyregex property="deployer-branch-or-tag" override="true" input="${spring-cloud-deployer-cloudfoundry.version}" regexp=".*\.(?:M\d+|RC\d+|RELEASE)" select="v\0" defaultValue="master" />
+										<propertyregex property="skipper-branch-or-tag" override="true" input="${spring-cloud-skipper.version}" regexp=".*\.(?:M\d+|RC\d+|RELEASE)" select="v\0" defaultValue="master" />
 									</target>
 								</configuration>
 							</execution>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -331,6 +331,377 @@ You will see the year `2017` printed in the logs. The execution status of the ta
 in the database and you can retrieve information about the task execution using the shell commands
 `task execution list` and `task execution status --id <ID_OF_TASK>` or though the Data Flow UI.
 
+[[spring-cloud-skipper-integration]]
+== Spring Cloud Skipper Integration
+
+Skipper is a tool that allows you to discover Spring Boot applications and manage their lifecycle on multiple Cloud Platforms.
+You can use Skipper standalone or integrate it with Continuous Integration pipelines to help achieve Continuous Deployment
+of applications. For more details, review the link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-version-type}/reference/htmlsingle/#overview[reference guide]
+for a complete overview and the feature capabilities.
+
+Before we begin setting up Skipper to use with Spring Cloud Data Flow, let's review the basics by understanding foundational
+design by which the relevant infrastructure is provisioned in Kubernetes. The tailormade
+link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-version-type}/reference/htmlsingle/#tour-cloud-foundry[three-minute-tour for Cloud Foundry]
+walks through the fundamentals.
+
+Next up, we will review the relevant artifacts to provision Spring Cloud Skipper in Cloud Foundry.
+
+=== Download the Spring Cloud Skipper and Shell apps
+
+[source,yaml,options=nowrap,subs=attributes]
+----
+wget http://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-server/{skipper-version}/spring-cloud-skipper-server-{skipper-version}.jar
+wget http://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-shell/{skipper-version}/spring-cloud-skipper-shell-{skipper-version}.jar
+----
+
+=== Running the Skipper Server
+Similar to SCDF-server, you can either deploy the skipper-server application on Cloud Foundry or on your local machine.
+
+Let's review the sample `manifest.yml` file to deploy the skipper-server application to Cloud Foundry.
+
+[source,yaml,options=nowrap]
+----
+---
+applications:
+- name: skipper-server
+  host: skipper-server
+  memory: 1G
+  disk_quota: 1G
+  instances: 1
+  path: <PATH TO THE DOWNLOADED SKIPPER SERVER UBER-JAR>
+env:
+    SPRING_APPLICATION_NAME: skipper-server
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_URL: https://api.run.pivotal.io
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_ORG: {org}
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_SPACE: {space}
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_DOMAIN: cfapps.io
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_USERNAME: {email}
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_PASSWORD: {password}
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_SERVICES: rabbit
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_STREAM_ENABLE_RANDOM_APP_NAME_PREFIX: false
+----
+
+You need to fill in \{org}, \{space}, \{email} and \{password} before running these commands. Once you have the desired
+config values in the `manifest.yml`, you can run `cf push` command to provision the skipper-server.
+
+WARNING: Only set 'Skip SSL Validation' to true if you're running on a Cloud Foundry instance using self-signed
+certs (e.g. in development). Do not use for production.
+
+[NOTE]
+====
+Skipper includes the concept of link:https://docs.spring.io/spring-cloud-skipper/docs/current/reference/htmlsingle/#platforms[platforms],
+so it is important to define the "accounts" based on the project preferences. In the above YAML file, the accounts map
+to `pws` as the platform. This can be modified, and of course, you can have any number of platform definitions.
+More details are in Spring Cloud Skipper reference guide.
+====
+
+=== Deploying Streams using Skipper
+We will proceed with the assumption that Spring Cloud Data Flow, Spring Cloud Skipper, RDBMS, and desired messaging
+middleware is up and running in PWS.
+
+[source,console,options=nowrap]
+----
+± cf apps                                                                                                                                                                                                                                         [1h] ✭
+Getting apps in org ORG / space SPACE as email@pivotal.io...
+OK
+
+name                         requested state   instances   memory   disk   urls
+skipper-server               started           1/1         1G       1G     skipper-server.cfapps.io
+dataflow-server              started           1/1         1G       1G     dataflow-server.cfapps.io
+----
+
+Verify the available platforms in Skipper.
+
+[source,console,options=nowrap]
+----
+skipper:>config http://skipper-server.cfapps.io/api
+Successfully targeted http://skipper-server.cfapps.io/api
+skipper:>platform list
+╔═══════╤════════════╤═════════════════════════════════════════════════════════════════════════════════════════════════════════════╗
+║ Name  │    Type    │                                                 Description                                                 ║
+╠═══════╪════════════╪═════════════════════════════════════════════════════════════════════════════════════════════════════════════╣
+║default│local       │ShutdownTimeout = [30], EnvVarsToInherit = [TMP,LANG,LANGUAGE,LC_.*,PATH], JavaCmd =                         ║
+║       │            │[/home/vcap/app/.java-buildpack/open_jdk_jre/bin/java], WorkingDirectoriesRoot = [/home/vcap/tmp],           ║
+║       │            │DeleteFilesOnExit = [true]                                                                                   ║
+║pws    │cloudfoundry│org = [org], space = [space], url = [https://api.run.pivotal.io]                                             ║
+╚═══════╧════════════╧═════════════════════════════════════════════════════════════════════════════════════════════════════════════╝
+----
+
+Let's start with deploying a stream with the `time-source` pointing to 1.2.0.RELEASE and `log-sink` pointing
+to 1.1.0.RELEASE. The goal is to rolling upgrade the `log-sink` application to 1.2.0.RELEASE.
+
+```
+dataflow:>app register --name time --type source --uri maven://org.springframework.cloud.stream.app:time-source-rabbit:1.2.0.RELEASE
+Successfully registered application 'source:time'
+
+dataflow:>app register --name log --type sink --uri maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.1.0.RELEASE
+Successfully registered application 'sink:log'
+
+dataflow:>app info source:time
+Information about source application 'time':
+Resource URI: maven://org.springframework.cloud.stream.app:time-source-rabbit:1.2.0.RELEASE
+
+dataflow:>app info sink:log
+Information about sink application 'log':
+Resource URI: maven://org.springframework.cloud.stream.app:log-sink-rabbit:1.1.0.RELEASE
+```
+
+. Create stream.
+
++
+```
+dataflow:>stream create foo --definition "time | log"
+Created new stream 'foo'
+```
++
+
+. Deploy stream.
+
++
+```
+dataflow:>stream skipper deploy foo --platformName pws
+Deployment request has been sent for stream 'foo'
+```
++
+
+[NOTE]
+====
+While deploying the stream, we are supplying `--platformName` and that indicates the platform repository (i.e., `pws`) to
+use when deploying the stream applications via Skipper.
+====
+
+. List apps.
+
++
+[source,console,options=nowrap]
+----
+$ cf apps                                                                                                                                                                                                                                         [1h] ✭
+Getting apps in org ORG / space SPACE as email@pivotal.io...
+
+name                         requested state   instances   memory   disk   urls
+foo-log-v1                   started           1/1         1G       1G     foo-log-v1.cfapps.io
+foo-time-v1                  started           1/1         1G       1G     foo-time-v1.cfapps.io
+skipper-server               started           1/1         1G       1G     skipper-server.cfapps.io
+dataflow-server              started           1/1         1G       1G     dataflow-server.cfapps.io
+----
++
+
+. Verify logs.
+
++
+[source,console,options=nowrap]
+----
+$ cf logs foo-log-v1
+...
+...
+2017-11-20T15:39:43.76-0800 [APP/PROC/WEB/0] OUT 2017-11-20 23:39:43.761  INFO 12 --- [ foo.time.foo-1] log-sink                                 : 11/20/17 23:39:43
+2017-11-20T15:39:44.75-0800 [APP/PROC/WEB/0] OUT 2017-11-20 23:39:44.757  INFO 12 --- [ foo.time.foo-1] log-sink                                 : 11/20/17 23:39:44
+2017-11-20T15:39:45.75-0800 [APP/PROC/WEB/0] OUT 2017-11-20 23:39:45.757  INFO 12 --- [ foo.time.foo-1] log-sink                                 : 11/20/17 23:39:45
+----
++
+
+. Verify history in Skipper.
+
++
+[source,console,options=nowrap]
+----
+skipper:>history --release-name foo
+╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
+║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
+╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
+║1      │Mon Nov 20 15:34:37 PST 2017│DEPLOYED│foo         │1.0.0          │Install complete║
+╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════╝
+----
++
+
+. Verify the package manifest in Skipper. The `log-sink` should be at 1.1.0.RELEASE.
+
++
+[source,yml,options=nowrap]
+----
+skipper:>manifest get foo
+
+---
+# Source: log.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: log
+spec:
+  resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit
+  version: 1.1.0.RELEASE
+  applicationProperties:
+    spring.cloud.dataflow.stream.app.label: log
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    spring.cloud.stream.bindings.applicationMetrics.destination: metrics
+    twitter.credentials.access-token-secret: a3CEjynO4R8basD2eIbLJlmuRKkx8dhsG0bOkb0FkIVqH
+    spring.cloud.dataflow.stream.name: foo
+    twitter.credentials.consumer-secret: I0lWLWNaroWlzC7q8TvrNWKCzgOj5k7qqYLS5Bbx2jpym0EU9U
+    twitter.credentials.consumer-key: DDp9YM9M9yfulJrydpkbn3QLL
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.stream.metrics.key: foo.log.${spring.cloud.application.guid}
+    spring.cloud.stream.bindings.input.group: foo
+    twitter.credentials.access-token: 17580836-OEb0NXhlrMULMGsyUlxVAzbwbWxPsFuJ9oVbaEHrX
+    spring.cloud.dataflow.stream.app.type: sink
+    spring.cloud.stream.bindings.input.destination: foo.time
+  deploymentProperties:
+    spring.cloud.deployer.indexed: true
+    spring.cloud.deployer.group: foo
+
+---
+# Source: time.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: time
+spec:
+  resource: maven://org.springframework.cloud.stream.app:time-source-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.cloud.dataflow.stream.app.label: time
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    spring.cloud.stream.bindings.applicationMetrics.destination: metrics
+    twitter.credentials.access-token-secret: a3CEjynO4R8basD2eIbLJlmuRKkx8dhsG0bOkb0FkIVqH
+    spring.cloud.dataflow.stream.name: foo
+    twitter.credentials.consumer-secret: I0lWLWNaroWlzC7q8TvrNWKCzgOj5k7qqYLS5Bbx2jpym0EU9U
+    twitter.credentials.consumer-key: DDp9YM9M9yfulJrydpkbn3QLL
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.stream.metrics.key: foo.time.${spring.cloud.application.guid}
+    spring.cloud.stream.bindings.output.producer.requiredGroups: foo
+    spring.cloud.stream.bindings.output.destination: foo.time
+    twitter.credentials.access-token: 17580836-OEb0NXhlrMULMGsyUlxVAzbwbWxPsFuJ9oVbaEHrX
+    spring.cloud.dataflow.stream.app.type: source
+  deploymentProperties:
+    spring.cloud.deployer.group: foo
+----
+
+. Let's update `log-sink` from 1.1.0.RELEASE to 1.2.0.RELEASE
+
++
+[source,console,options=nowrap]
+----
+dataflow:>stream skipper update --name foo --properties version.log=1.2.0.RELEASE
+Update request has been sent for stream 'foo'
+----
++
+
+. List apps.
+
++
+[source,console,options=nowrap]
+----
+± cf apps                                                                                                                                                                                                                                         [1h] ✭
+Getting apps in org ORG / space SPACE as email@pivotal.io...
+
+Getting apps in org scdf-ci / space space-sabby as sanandan@pivotal.io...
+OK
+
+name                         requested state   instances   memory   disk   urls
+foo-log-v2                   started           1/1         1G       1G     foo-log-v2.cfapps.io
+foo-log-v1                   stopped           0/1         1G       1G
+foo-time-v1                  started           1/1         1G       1G     foo-time-v1.cfapps.io
+skipper-server               started           1/1         1G       1G     skipper-server.cfapps.io
+dataflow-server              started           1/1         1G       1G     dataflow-server.cfapps.io
+----
++
+
+[NOTE]
+====
+Notice that there are two versions of the `log-sink` applications. The `foo-log-v1` application instance is going down
+(route already removed) and the newly spawned `foo-log-v2` application is bootstrapping. The version number is incremented and
+the version-number (`v2`) is included in the new application name.
+====
+
+. Once the new application is up and running, let's verify the logs.
+
++
+[source,console,options=nowrap]
+----
+$ cf logs foo-log-v2
+...
+...
+2017-11-20T18:38:35.00-0800 [APP/PROC/WEB/0] OUT 2017-11-21 02:38:35.003  INFO 18 --- [foo.time.foo-1] foo-log-v2                              : 11/21/17 02:38:34
+2017-11-20T18:38:36.00-0800 [APP/PROC/WEB/0] OUT 2017-11-21 02:38:36.004  INFO 18 --- [foo.time.foo-1] foo-log-v2                              : 11/21/17 02:38:35
+2017-11-20T18:38:37.00-0800 [APP/PROC/WEB/0] OUT 2017-11-21 02:38:37.005  INFO 18 --- [foo.time.foo-1] foo-log-v2                              : 11/21/17 02:38:36
+----
++
+
+. Let's look at the updated package manifest in Skipper. We should now be seeing `log-sink` at 1.2.0.RELEASE.
+
++
+[source,yml,options=nowrap]
+----
+skipper:>manifest get --release-name foo
+
+---
+# Source: log.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: log
+spec:
+  resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.cloud.dataflow.stream.app.label: log
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    spring.cloud.stream.bindings.applicationMetrics.destination: metrics
+    twitter.credentials.access-token-secret: a3CEjynO4R8basD2eIbLJlmuRKkx8dhsG0bOkb0FkIVqH
+    spring.cloud.dataflow.stream.name: foo
+    twitter.credentials.consumer-secret: I0lWLWNaroWlzC7q8TvrNWKCzgOj5k7qqYLS5Bbx2jpym0EU9U
+    twitter.credentials.consumer-key: DDp9YM9M9yfulJrydpkbn3QLL
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.stream.metrics.key: foo.log.${spring.cloud.application.guid}
+    spring.cloud.stream.bindings.input.group: foo
+    twitter.credentials.access-token: 17580836-OEb0NXhlrMULMGsyUlxVAzbwbWxPsFuJ9oVbaEHrX
+    spring.cloud.dataflow.stream.app.type: sink
+    spring.cloud.stream.bindings.input.destination: foo.time
+  deploymentProperties:
+    spring.cloud.deployer.indexed: true
+    spring.cloud.deployer.group: foo
+    spring.cloud.deployer.count: 1
+
+---
+# Source: time.yml
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: time
+spec:
+  resource: maven://org.springframework.cloud.stream.app:time-source-rabbit
+  version: 1.2.0.RELEASE
+  applicationProperties:
+    spring.cloud.dataflow.stream.app.label: time
+    spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
+    spring.cloud.stream.bindings.applicationMetrics.destination: metrics
+    twitter.credentials.access-token-secret: a3CEjynO4R8basD2eIbLJlmuRKkx8dhsG0bOkb0FkIVqH
+    spring.cloud.dataflow.stream.name: foo
+    twitter.credentials.consumer-secret: I0lWLWNaroWlzC7q8TvrNWKCzgOj5k7qqYLS5Bbx2jpym0EU9U
+    twitter.credentials.consumer-key: DDp9YM9M9yfulJrydpkbn3QLL
+    spring.metrics.export.triggers.application.includes: integration**
+    spring.cloud.stream.metrics.key: foo.time.${spring.cloud.application.guid}
+    spring.cloud.stream.bindings.output.producer.requiredGroups: foo
+    spring.cloud.stream.bindings.output.destination: foo.time
+    twitter.credentials.access-token: 17580836-OEb0NXhlrMULMGsyUlxVAzbwbWxPsFuJ9oVbaEHrX
+    spring.cloud.dataflow.stream.app.type: source
+  deploymentProperties:
+    spring.cloud.deployer.group: foo
+----
+
+. Verify history in Skipper.
+
++
+[source,console,options=nowrap]
+----
+skipper:>history --release-name foo
+╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
+║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
+╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
+║2      │Mon Oct 30 16:21:55 PDT 2017│DEPLOYED│foo         │1.0.0          │Upgrade complete║
+║1      │Mon Oct 30 16:18:28 PDT 2017│DELETED │foo         │1.0.0          │Delete complete ║
+╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════╝
+----
+
 [[getting-started-app-names-cloud-foundry]]
 == Application Names and Prefixes
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -336,12 +336,12 @@ in the database and you can retrieve information about the task execution using 
 
 Skipper is a tool that allows you to discover Spring Boot applications and manage their lifecycle on multiple Cloud Platforms.
 You can use Skipper standalone or integrate it with Continuous Integration pipelines to help achieve Continuous Deployment
-of applications. For more details, review the link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-version-type}/reference/htmlsingle/#overview[reference guide]
+of applications. For more details, review the link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-version}/reference/htmlsingle/#overview[reference guide]
 for a complete overview and the feature capabilities.
 
 Before we begin setting up Skipper to use with Spring Cloud Data Flow, let's review the basics by understanding foundational
 design by which the relevant infrastructure is provisioned in Kubernetes. The tailormade
-link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-version-type}/reference/htmlsingle/#tour-cloud-foundry[three-minute-tour for Cloud Foundry]
+link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-version}/reference/htmlsingle/#tour-cloud-foundry[three-minute-tour for Cloud Foundry]
 walks through the fundamentals.
 
 Next up, we will review the relevant artifacts to provision Spring Cloud Skipper in Cloud Foundry.
@@ -534,14 +534,10 @@ spec:
     spring.cloud.dataflow.stream.app.label: log
     spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
     spring.cloud.stream.bindings.applicationMetrics.destination: metrics
-    twitter.credentials.access-token-secret: a3CEjynO4R8basD2eIbLJlmuRKkx8dhsG0bOkb0FkIVqH
     spring.cloud.dataflow.stream.name: foo
-    twitter.credentials.consumer-secret: I0lWLWNaroWlzC7q8TvrNWKCzgOj5k7qqYLS5Bbx2jpym0EU9U
-    twitter.credentials.consumer-key: DDp9YM9M9yfulJrydpkbn3QLL
     spring.metrics.export.triggers.application.includes: integration**
     spring.cloud.stream.metrics.key: foo.log.${spring.cloud.application.guid}
     spring.cloud.stream.bindings.input.group: foo
-    twitter.credentials.access-token: 17580836-OEb0NXhlrMULMGsyUlxVAzbwbWxPsFuJ9oVbaEHrX
     spring.cloud.dataflow.stream.app.type: sink
     spring.cloud.stream.bindings.input.destination: foo.time
   deploymentProperties:
@@ -561,15 +557,11 @@ spec:
     spring.cloud.dataflow.stream.app.label: time
     spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
     spring.cloud.stream.bindings.applicationMetrics.destination: metrics
-    twitter.credentials.access-token-secret: a3CEjynO4R8basD2eIbLJlmuRKkx8dhsG0bOkb0FkIVqH
     spring.cloud.dataflow.stream.name: foo
-    twitter.credentials.consumer-secret: I0lWLWNaroWlzC7q8TvrNWKCzgOj5k7qqYLS5Bbx2jpym0EU9U
-    twitter.credentials.consumer-key: DDp9YM9M9yfulJrydpkbn3QLL
     spring.metrics.export.triggers.application.includes: integration**
     spring.cloud.stream.metrics.key: foo.time.${spring.cloud.application.guid}
     spring.cloud.stream.bindings.output.producer.requiredGroups: foo
     spring.cloud.stream.bindings.output.destination: foo.time
-    twitter.credentials.access-token: 17580836-OEb0NXhlrMULMGsyUlxVAzbwbWxPsFuJ9oVbaEHrX
     spring.cloud.dataflow.stream.app.type: source
   deploymentProperties:
     spring.cloud.deployer.group: foo
@@ -646,14 +638,10 @@ spec:
     spring.cloud.dataflow.stream.app.label: log
     spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
     spring.cloud.stream.bindings.applicationMetrics.destination: metrics
-    twitter.credentials.access-token-secret: a3CEjynO4R8basD2eIbLJlmuRKkx8dhsG0bOkb0FkIVqH
     spring.cloud.dataflow.stream.name: foo
-    twitter.credentials.consumer-secret: I0lWLWNaroWlzC7q8TvrNWKCzgOj5k7qqYLS5Bbx2jpym0EU9U
-    twitter.credentials.consumer-key: DDp9YM9M9yfulJrydpkbn3QLL
     spring.metrics.export.triggers.application.includes: integration**
     spring.cloud.stream.metrics.key: foo.log.${spring.cloud.application.guid}
     spring.cloud.stream.bindings.input.group: foo
-    twitter.credentials.access-token: 17580836-OEb0NXhlrMULMGsyUlxVAzbwbWxPsFuJ9oVbaEHrX
     spring.cloud.dataflow.stream.app.type: sink
     spring.cloud.stream.bindings.input.destination: foo.time
   deploymentProperties:
@@ -674,15 +662,11 @@ spec:
     spring.cloud.dataflow.stream.app.label: time
     spring.cloud.stream.metrics.properties: spring.application.name,spring.application.index,spring.cloud.application.*,spring.cloud.dataflow.*
     spring.cloud.stream.bindings.applicationMetrics.destination: metrics
-    twitter.credentials.access-token-secret: a3CEjynO4R8basD2eIbLJlmuRKkx8dhsG0bOkb0FkIVqH
     spring.cloud.dataflow.stream.name: foo
-    twitter.credentials.consumer-secret: I0lWLWNaroWlzC7q8TvrNWKCzgOj5k7qqYLS5Bbx2jpym0EU9U
-    twitter.credentials.consumer-key: DDp9YM9M9yfulJrydpkbn3QLL
     spring.metrics.export.triggers.application.includes: integration**
     spring.cloud.stream.metrics.key: foo.time.${spring.cloud.application.guid}
     spring.cloud.stream.bindings.output.producer.requiredGroups: foo
     spring.cloud.stream.bindings.output.destination: foo.time
-    twitter.credentials.access-token: 17580836-OEb0NXhlrMULMGsyUlxVAzbwbWxPsFuJ9oVbaEHrX
     spring.cloud.dataflow.stream.app.type: source
   deploymentProperties:
     spring.cloud.deployer.group: foo


### PR DESCRIPTION
- Add skipper provisioning steps for PWS
- Add stream create, deploy, and update samples
- Include skipper server/shell regex section in the pom.xml