### PR TITLE
Remove SpringBoot dependency override

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry/pom.xml
@@ -13,17 +13,6 @@
 	<properties>
 		<start-class>org.springframework.cloud.dataflow.server.cloudfoundry.CloudFoundryDataFlowServer</start-class>
 	</properties>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-dependencies</artifactId>
-				<version>1.5.12.RELEASE</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
 Depends on https://github.com/spring-cloud/spring-cloud-dataflow/pull/2285

 - #2285 sets the correct boot version as well as the required MariaDB 2.2.5
 - Current SB override forces Maria 1.5.9 (as Spring 1.5.x dependecy)