### PR TITLE
Conditionally bootstrap SchedulerAutoConfiguration only when Scheduler is enabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<!-- skipper version used only in doc generation -->
 		<spring-cloud-skipper.version>1.0.7.RELEASE</spring-cloud-skipper.version>
 		<spring-cloud-scheduler-cloudfoundry>1.0.0.BUILD-SNAPSHOT</spring-cloud-scheduler-cloudfoundry>
+		<pivotal-cf-client-reactor.version>1.1.0.RELEASE</pivotal-cf-client-reactor.version>
 		<reactor.version>3.1.8.RELEASE</reactor.version>
 	</properties>
 

--- a/spring-cloud-dataflow-server-cloudfoundry-autoconfig/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry-autoconfig/pom.xml
@@ -59,5 +59,20 @@
 			<artifactId>spring-cloud-sso-connector</artifactId>
 			<version>1.1.0.RELEASE</version>
 		</dependency>
+		<dependency>
+			<groupId>io.pivotal</groupId>
+			<artifactId>pivotal-cloudfoundry-client-reactor</artifactId>
+			<version>${pivotal-cf-client-reactor.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-scheduler-spi</artifactId>
+			<version>${spring-cloud-scheduler-spi.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-scheduler-cloudfoundry</artifactId>
+			<version>${spring-cloud-scheduler-cloudfoundry}</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundrySchedulerConfiguration.java
+++ b/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundrySchedulerConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.server.cloudfoundry.config;
+
+import io.pivotal.reactor.scheduler.ReactorSchedulerClient;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.reactor.ConnectionContext;
+import org.cloudfoundry.reactor.TokenProvider;
+import reactor.core.publisher.Mono;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.dataflow.server.config.features.SchedulerConfiguration;
+import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundry2630AndLaterTaskLauncher;
+import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryConnectionProperties;
+import org.springframework.cloud.deployer.spi.task.TaskLauncher;
+import org.springframework.cloud.scheduler.spi.cloudfoundry.CloudFoundryAppScheduler;
+import org.springframework.cloud.scheduler.spi.cloudfoundry.CloudFoundrySchedulerProperties;
+import org.springframework.cloud.scheduler.spi.core.Scheduler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Mark Pollack
+ */
+@Configuration
+@Conditional({ SchedulerConfiguration.SchedulerConfigurationPropertyChecker.class })
+public class CloudFoundrySchedulerConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ReactorSchedulerClient reactorSchedulerClient(ConnectionContext context,
+			TokenProvider passwordGrantTokenProvider,
+			CloudFoundrySchedulerProperties properties) {
+		return ReactorSchedulerClient.builder()
+				.connectionContext(context)
+				.tokenProvider(passwordGrantTokenProvider)
+				.root(Mono.just(properties.getSchedulerUrl()))
+				.build();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public Scheduler scheduler(ReactorSchedulerClient client,
+			CloudFoundryOperations operations,
+			CloudFoundryConnectionProperties properties,
+			TaskLauncher taskLauncher,
+			CloudFoundrySchedulerProperties schedulerProperties) {
+		return new CloudFoundryAppScheduler(client, operations, properties,
+				(CloudFoundry2630AndLaterTaskLauncher) taskLauncher,
+				schedulerProperties);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public CloudFoundrySchedulerProperties cloudFoundrySchedulerProperties() {
+		return new CloudFoundrySchedulerProperties();
+	}
+}

--- a/spring-cloud-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry/pom.xml
@@ -34,11 +34,6 @@
 			<artifactId>spring-cloud-spring-service-connector</artifactId>
 			<version>${spring-cloud-cloudfoundry-connector}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-scheduler-cloudfoundry</artifactId>
-			<version>${spring-cloud-scheduler-cloudfoundry}</version>
-		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-dataflow-server-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/CloudFoundryDataFlowServer.java
+++ b/spring-cloud-dataflow-server-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/CloudFoundryDataFlowServer.java
@@ -20,13 +20,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
 import org.springframework.cloud.dataflow.server.EnableDataFlowServer;
+import org.springframework.cloud.scheduler.spi.cloudfoundry.CloudFoundrySchedulerAutoConfiguration;
 
 /**
  * Bootstrap class for the Cloud Foundry Spring Cloud Data Flow Server.
  *
  * @author Eric Bottard
  */
-@SpringBootApplication(exclude = SessionAutoConfiguration.class)
+@SpringBootApplication(exclude = {SessionAutoConfiguration.class, CloudFoundrySchedulerAutoConfiguration.class} )
 @EnableDataFlowServer
 public class CloudFoundryDataFlowServer {
 


### PR DESCRIPTION
Fixes #429 

Depends on fix in scdf core to remove `matchIfMissing` condition inside `SchedulerConfigurationPropertyChecker`