### PR TITLE
Make Scheduler auto-configurable

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.springframework.cloud.dataflow.server.cloudfoundry.config.CloudFoundryDataFlowServerConfiguration
+  org.springframework.cloud.dataflow.server.cloudfoundry.config.CloudFoundryDataFlowServerConfiguration,\
+  org.springframework.cloud.dataflow.server.cloudfoundry.config.CloudFoundrySchedulerConfiguration
 org.springframework.boot.env.EnvironmentPostProcessor=\
   org.springframework.cloud.dataflow.server.cloudfoundry.config.TaskFeatureAutoToggleEnvironmentPostProcessor


### PR DESCRIPTION
The scheduler config doesn't get pulled in by the auto-config. It does get pulled in by the default `CloudFoundryDataFlowServer` because the config is in a sub-package of the auto-config classes.