### PR TITLE
Test Task/Batch workloads on Skipper mode

### DIFF
--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/configuration.adoc
@@ -489,12 +489,6 @@ spring.cloud.deployer.cloudfoundry.password=
 # (to set the environment variable, use SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SKIP_SSL_VALIDATION).
 spring.cloud.deployer.cloudfoundry.skipSslValidation=false
 
-# A comma-separated set of service instance names to bind to every deployed stream application.
-# Among other things, this should include a service that is used
-# for Spring Cloud Stream binding, such as Rabbit
-# (to set the environment variable, use SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES).
-spring.cloud.deployer.cloudfoundry.stream.services=
-
 # The health check type to use for stream apps. Accepts 'none' and 'port'.
 spring.cloud.deployer.cloudfoundry.stream.health-check=
 
@@ -609,9 +603,7 @@ Another, more drastic, option is to disable the platform health check by setting
 
 === Sample Manifest Template
 
-The following `manifest.yml` template includes the required environment variables for the Spring Cloud Data Flow server and deployed
-applications and tasks to successfully run on Cloud Foundry and automatically resolve centralized properties from `my-config-server`
-at runtime:
+The following SCDF and Skipper `manifest.yml` templates includes the required environment variables for the Skipper and Spring Cloud Data Flow server and deployed applications and tasks to successfully run on Cloud Foundry and automatically resolve centralized properties from `my-config-server` at runtime:
 
 ====
 [source,yml]
@@ -632,7 +624,6 @@ applications:
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_DOMAIN: local.pcfdev.io
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_USERNAME: admin
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_PASSWORD: admin
-    SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES: rabbit,my-config-server
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES: mysql,my-config-server
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SKIP_SSL_VALIDATION: true
     SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI: https://<skipper-host-name>/api
@@ -640,28 +631,50 @@ applications:
 services:
 - mysql
 - my-config-server
+
+---
+applications:
+- name: skipper-server
+  host: skipper-server
+  memory: 1G
+  disk_quota: 1G
+  instances: 1
+  timeout: 180
+  buildpack: java_buildpack
+  path: <PATH TO THE DOWNLOADED SKIPPER SERVER UBER-JAR>
+  env:
+    SPRING_APPLICATION_NAME: skipper-server
+    SPRING_CLOUD_SKIPPER_SERVER_ENABLE_LOCAL_PLATFORM: false
+    SPRING_CLOUD_SKIPPER_SERVER_STRATEGIES_HEALTHCHECK_TIMEOUTINMILLIS: 300000
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_URL: https://api.local.pcfdev.io
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_ORG: pcfdev-org
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_SPACE: pcfdev-space
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_DOMAIN: cfapps.io
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_USERNAME: admin
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_PASSWORD: admin
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_SKIP_SSL_VALIDATION: false
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_DELETE_ROUTES: false
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_SERVICES: rabbit, my-config-server
+services:
+- mysql
+  my-config-server
+
 ----
 
 where `my-config-server` is the name of the Spring Cloud Config Service instance running on Cloud Foundry.
 ====
 
-By binding the
-service to both Spring Cloud Data Flow server and all the Spring Cloud Stream and Spring Cloud Task applications
-respectively, we can now resolve centralized properties backed by this service.
+By binding the service to both Spring Cloud Data Flow server and Spring Cloud Task and via Skipper to all the Spring Cloud Stream applications respectively, we can now resolve centralized properties backed by this service.
 
 === Self-signed SSL Certificate and Spring Cloud Config Server
 
-Often, in a development environment, we may not have a valid certificate to enable SSL communication between clients and
-the backend services. However, the configuration server for Pivotal Cloud Foundry uses HTTPS for all client-to-service communication,
-so we need to add a self-signed SSL certificate in environments with no valid certificates.
+Often, in a development environment, we may not have a valid certificate to enable SSL communication between clients and the backend services.
+However, the configuration server for Pivotal Cloud Foundry uses HTTPS for all client-to-service communication, so we need to add a self-signed SSL certificate in environments with no valid certificates.
 
-By using the same `manifest.yml` template listed in the previous section for the server, we can provide the self-signed
-SSL certificate by setting `TRUST_CERTS: <API_ENDPOINT>`.
+By using the same `manifest.yml` templates listed in the previous section for the server, we can provide the self-signed SSL certificate by setting `TRUST_CERTS: <API_ENDPOINT>`.
 
-However, the deployed applications also require `TRUST_CERTS` as a flat environment variable (as opposed to being wrapped inside
-`SPRING_APPLICATION_JSON`), so we must instruct the server with yet another set of tokens (`SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_USE_SPRING_APPLICATION_JSON: false`
-and `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_USE_SPRING_APPLICATION_JSON: false`) for stream and task applications,
-respectively. With this setup, the applications receive their application properties as regular environment variables.
+However, the deployed applications also require `TRUST_CERTS` as a flat environment variable (as opposed to being wrapped inside `SPRING_APPLICATION_JSON`), so we must instruct the server with yet another set of tokens (`SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_USE_SPRING_APPLICATION_JSON: false` and `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_USE_SPRING_APPLICATION_JSON: false`) for stream and task applications, respectively.
+With this setup, the applications receive their application properties as regular environment variables.
 
 The following listing shows the updated `manifest.yml` with the required changes. Both the Data Flow server and deployed applications
 get their configuration from the `my-config-server` Cloud Config server (deployed as a Cloud Foundry service).
@@ -687,7 +700,6 @@ applications:
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_PASSWORD: <PASSWORD>
     SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI: https://<skipper-host-name>/api
     MAVEN_REMOTE_REPOSITORIES_REPO1_URL: https://repo.spring.io/libs-release
-    SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES: my-config-server #this is so all stream applications bind to my-config-server
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES: config-server      #this for so all task applications bind to my-config-server
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_USE_SPRING_APPLICATION_JSON: false #this is for all the stream applications
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_USE_SPRING_APPLICATION_JSON: false #this is for all the task applications
@@ -700,34 +712,62 @@ services:
 ----
 ====
 
+Also add the `my-config-server` service to the Skipper's manifest environment
+
+====
+[source,yml]
+----
+---
+applications:
+- name: skipper-server
+  host: skipper-server
+  memory: 1G
+  disk_quota: 1G
+  instances: 1
+  timeout: 180
+  buildpack: java_buildpack
+  path: <PATH TO THE DOWNLOADED SKIPPER SERVER UBER-JAR>
+  env:
+    SPRING_APPLICATION_NAME: skipper-server
+    SPRING_CLOUD_SKIPPER_SERVER_ENABLE_LOCAL_PLATFORM: false
+    SPRING_CLOUD_SKIPPER_SERVER_STRATEGIES_HEALTHCHECK_TIMEOUTINMILLIS: 300000
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_URL: <URL>
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_ORG: <ORG>
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_SPACE: <SPACE>
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_DOMAIN: <DOMAIN>
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_USERNAME: <USER>
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_PASSWORD: <PASSWORD>
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_SERVICES: rabbit, my-config-server #this is so all stream applications bind to my-config-server
+services:
+- mysql
+  my-config-server
+
+----
+====
+
 [[getting-started-scheduling-configuration]]
 == Configure Scheduling
-This section discusses how to configure Spring Cloud Data Flow to connect to the
-https://www.cloudfoundry.org/the-foundry/scheduler/[PCF-Scheduler] as its agent to execute tasks.
+This section discusses how to configure Spring Cloud Data Flow to connect to the https://www.cloudfoundry.org/the-foundry/scheduler/[PCF-Scheduler] as its agent to execute tasks.
 
 [NOTE]
 ====
-Before following these instructions, be sure to have an instance of the PCF-Scheduler service running in your Cloud
-Foundry space.  To create a PCF-Scheduler in your space (assuming it is in your Market Place) execute the following
-from the CF CLI: `cf create-service scheduler-for-pcf standard <name of service>`. Name of a service
-is later used to bound running application in _PCF_.
+Before following these instructions, be sure to have an instance of the PCF-Scheduler service running in your Cloud Foundry space.
+To create a PCF-Scheduler in your space (assuming it is in your Market Place) execute the following from the CF CLI: `cf create-service scheduler-for-pcf standard <name of service>`.
+Name of a service is later used to bound running application in _PCF_.
 ====
 
 For scheduling, you must add (or update) the following environment variables in your environment:
 
 * Enable scheduling for Spring Cloud Data Flow by setting `spring.cloud.dataflow.features.schedules-enabled` to `true`.
-* Bind the task deployer to your instance of PCF-Scheduler by adding the PCF-Scheduler service name to the
-  `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES` environment variable.
-* Establish the URL to the PCF-Scheduler by setting the `SPRING_CLOUD_SCHEDULER_CLOUDFOUNDRY_SCHEDULER_URL` environment
-  variable.
+* Bind the task deployer to your instance of PCF-Scheduler by adding the PCF-Scheduler service name to the `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES` environment variable.
+* Establish the URL to the PCF-Scheduler by setting the `SPRING_CLOUD_SCHEDULER_CLOUDFOUNDRY_SCHEDULER_URL` environment variable.
 
 [NOTE]
 ====
 After creating the preceding configurations, you must create any task definitions that need to be scheduled.
 ====
 
-The following sample manifest shows both environment properties configured (assuming you have a PCF-Scheduler service
-available with the name `myscheduler`):
+The following sample manifest shows both environment properties configured (assuming you have a PCF-Scheduler service available with the name `myscheduler`):
 
 ====
 [source,yml]
@@ -748,7 +788,6 @@ applications:
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_DOMAIN: local.pcfdev.io
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_USERNAME: admin
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_PASSWORD: admin
-    SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES: rabbit
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES: mysql,myscheduler
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SKIP_SSL_VALIDATION: true
     SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED: true

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/configuration.adoc
@@ -664,7 +664,7 @@ services:
 where `my-config-server` is the name of the Spring Cloud Config Service instance running on Cloud Foundry.
 ====
 
-By binding the service to both Spring Cloud Data Flow server and Spring Cloud Task and via Skipper to all the Spring Cloud Stream applications respectively, we can now resolve centralized properties backed by this service.
+By binding the service to Spring Cloud Data Flow server, Spring Cloud Task and via Skipper to all the Spring Cloud Stream applications respectively, we can now resolve centralized properties backed by this service.
 
 === Self-signed SSL Certificate and Spring Cloud Config Server
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/configuration.adoc
@@ -635,6 +635,7 @@ applications:
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES: rabbit,my-config-server
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES: mysql,my-config-server
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SKIP_SSL_VALIDATION: true
+    SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI: https://<skipper-host-name>/api
     SPRING_APPLICATION_JSON: '{"maven": { "remote-repositories": { "repo1": { "url": "https://repo.spring.io/libs-release"} } } }'
 services:
 - mysql
@@ -684,6 +685,7 @@ applications:
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_DOMAIN: <DOMAIN>
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_USERNAME: <USER>
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_PASSWORD: <PASSWORD>
+    SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI: https://<skipper-host-name>/api
     MAVEN_REMOTE_REPOSITORIES_REPO1_URL: https://repo.spring.io/libs-release
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES: my-config-server #this is so all stream applications bind to my-config-server
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES: config-server      #this for so all task applications bind to my-config-server
@@ -750,6 +752,7 @@ applications:
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES: mysql,myscheduler
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SKIP_SSL_VALIDATION: true
     SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED: true
+    SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI: https://<skipper-host-name>/api
     SPRING_CLOUD_SCHEDULER_CLOUDFOUNDRY_SCHEDULER_URL: https://scheduler.local.pcfdev.io
     SPRING_APPLICATION_JSON: '{"maven": { "remote-repositories": { "repo1": { "url": "https://repo.spring.io/libs-release"} } } }'
 services:

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -4,23 +4,19 @@
 [[getting-started-requirements]]
 == System Requirements
 
-The Spring Cloud Data Flow server deploys streams (long-lived applications) and tasks (short-lived applications) to Cloud
-Foundry. The server is a lightweight Spring Boot application. It can run on Cloud Foundry or your laptop, but it is more
-common to run the server in Cloud Foundry.
+The Spring Cloud Data Flow server deploys streams (long-lived applications) and tasks (short-lived applications) to Cloud Foundry.
+The server is a lightweight Spring Boot application. It can run on Cloud Foundry or your laptop, but it is more common to run the server in Cloud Foundry.
 
-Spring Cloud Data Flow requires a few data services to perform streaming, task/batch processing, and analytics. You have
-two options when you provision Spring Cloud Data Flow and related services on Cloud Foundry:
+Spring Cloud Data Flow requires a few data services to perform streaming, task/batch processing, and analytics.
+You have two options when you provision Spring Cloud Data Flow and related services on Cloud Foundry:
 
-* The simplest (and automated) method is to use the link:https://network.pivotal.io/products/p-dataflow[Spring Cloud Data Flow for PCF]
-tile. This is an opinionated tile for Pivotal Cloud Foundry. It automatically provisions the server and the required
-data services, thus simplifying the overall getting-started experience. You can read more about the installation
-link:http://docs.pivotal.io/scdf/[here].
-* Alternatively, you can provision all the components manually. The following section goes into the specifics of how to
-do so.
+* The simplest (and automated) method is to use the link:https://network.pivotal.io/products/p-dataflow[Spring Cloud Data Flow for PCF] tile.
+This is an opinionated tile for Pivotal Cloud Foundry.
+It automatically provisions the server and the required data services, thus simplifying the overall getting-started experience. You can read more about the installation link:http://docs.pivotal.io/scdf/[here].
+* Alternatively, you can provision all the components manually. The following section goes into the specifics of how to do so.
 
 === Provision a Redis Service Instance on Cloud Foundry
-A Redis instance is required for analytics apps and is typically bound to such apps when you create an analytics
-stream by using the <<getting-started.adoc#getting-started-service-binding-at-application-level,per-app-binding>> feature.
+A Redis instance is required for analytics apps and is typically bound to such apps when you create an analytics stream by using the <<getting-started.adoc#getting-started-service-binding-at-application-level,per-app-binding>> feature.
 
 You can use `cf marketplace` to discover which plans are available to you, depending on the details of your Cloud Foundry setup.
 For example, you can use link:https://run.pivotal.io/[Pivotal Web Services], as the following example shows:
@@ -33,10 +29,9 @@ cf create-service rediscloud 30mb redis
 ====
 
 === Provision a Rabbit Service Instance on Cloud Foundry
-RabbitMQ is used as a messaging middleware between streaming apps and is bound to each deployed streaming
-app. Apache Kafka is the other option. We can use the `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES` setting in Data
-Flow configuration or use the `SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_SERVICES` setting in
-Skipper, which automatically binds RabbitMQ to the deployed streaming applications.
+RabbitMQ is used as a messaging middleware between streaming apps and is bound to each deployed streaming app.
+Apache Kafka is the other option.
+We can use the `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES` setting in Data Flow configuration or use the `SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_SERVICES` setting in Skipper, which automatically binds RabbitMQ to the deployed streaming applications.
 
 You can use `cf marketplace` to discover which plans are available to you, depending on the details of your Cloud Foundry setup.
 For example, you can use link:https://run.pivotal.io/[Pivotal Web Services]:
@@ -63,9 +58,7 @@ cf create-service cleardb spark my_mysql
 
 [[getting-started-cloudfoundry]]
 == Cloud Foundry Installation
-Starting with 1.3.x, the Data Flow Server can run in either `skipper` or `classic` (non-skipper) mode. You can specify the mode
-when you start the Data Flow server by setting the `spring.cloud.dataflow.features.skipper-enabled` property.
-By default, the `classic` mode is enabled.
+Starting with 2.0.x, the Data Flow Server requires a `Skipper` server for managing the Streams lifecycle.
 
 . Download the Data Flow server and shell applications, as the following example shows:
 +
@@ -77,7 +70,8 @@ wget http://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/sp
 wget http://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 ----
 ====
-. Optionally, download http://cloud.spring.io/spring-cloud-skipper/[Skipper] if you want the added features of upgrading and rolling back Streams since Data Flow delegates to Skipper for those features. The following example shows how to do so:
+. Download http://cloud.spring.io/spring-cloud-skipper/[Skipper] to which Data Flow delegate Streams lifecycle operations such as deployment, upgrading and rolling.
+The following example shows how to do so:
 +
 ====
 [source,yaml,options=nowrap,subs=attributes]
@@ -86,8 +80,7 @@ wget http://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/
 ----
 ====
 +
-Push Skipper to Cloud Foundry only if you want to run Spring Cloud Data Flow server in `skipper` mode.  The following example shows a
-manifest for Skipper.
+Push Skipper to Cloud Foundry.  The following example shows a manifest for Skipper.
 +
 ====
 [source,yaml,options=nowrap]
@@ -100,24 +93,29 @@ applications:
   disk_quota: 1G
   instances: 1
   timeout: 180
+  buildpack: java_buildpack
   path: <PATH TO THE DOWNLOADED SKIPPER SERVER UBER-JAR>
-env:
+  env:
     SPRING_APPLICATION_NAME: skipper-server
     SPRING_CLOUD_SKIPPER_SERVER_ENABLE_LOCAL_PLATFORM: false
-    SPRING_CLOUD_SKIPPER_SERVER_STRATEGIES_HEALTHCHECK.TIMEOUTINMILLIS: 300000
+    SPRING_CLOUD_SKIPPER_SERVER_STRATEGIES_HEALTHCHECK_TIMEOUTINMILLIS: 300000
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_URL: https://api.run.pivotal.io
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_ORG: {org}
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_SPACE: {space}
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_DOMAIN: cfapps.io
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_USERNAME: {email}
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_PASSWORD: {password}
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_SKIP_SSL_VALIDATION: false
-    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_DOMAIN: cfapps.io
+    SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_DELETE_ROUTES: false
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_SERVICES: {middlewareServiceName}
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_STREAM_ENABLE_RANDOM_APP_NAME_PREFIX: false
+services:
+- {services}
 ----
 ====
 +
-You need to fill in `\{org}`, `\{space}`, `\{email}`,  `\{password}` and `{middlewareServiceName}` before running these commands. Once you have the desired config values in `manifest.yml`, you can run the `cf push` command to provision the skipper-server.
+You need to fill in `\{org}`, `\{space}`, `\{email}`,  `\{password}`, `{middlewareServiceName}` (e.g. rabbit or kafka) and {services} (such as mysql) before running these commands.
+Once you have the desired config values in `manifest.yml`, you can run the `cf push` command to provision the skipper-server.
 +
 WARNING: Only set 'Skip SSL Validation' to `true` if you run on a Cloud Foundry instance by using self-signed
 certificates (for example, in development). Do not use self-signed certificates for production.
@@ -125,8 +123,7 @@ certificates (for example, in development). Do not use self-signed certificates 
 . Configure and run the Data Flow Server
 +
 One of the most important configuration details is providing credentials to the Cloud Foundry instance so that the server can itself spawn applications.
-You can use any Spring Boot-compatible configuration mechanism (passing program arguments, editing configuration files before building the application, using
-link:https://github.com/spring-cloud/spring-cloud-config[Spring Cloud Config], using environment variables, and others), although some may prove more practicable than others, depending on how you typically deploy applications to Cloud Foundry.
+You can use any Spring Boot-compatible configuration mechanism (passing program arguments, editing configuration files before building the application, using link:https://github.com/spring-cloud/spring-cloud-config[Spring Cloud Config], using environment variables, and others), although some may prove more practicable than others, depending on how you typically deploy applications to Cloud Foundry.
 
 In later sections, we show how to deploy Data Flow by using <<getting-started-cloudfoundry-deploying-using-env-vars,environment variables>> or a <<getting-started-cloudfoundry-deploying-using-manifest,Cloud Foundry manifest>>.
 However, there are some general configuration details you should be aware of in either approach.
@@ -134,27 +131,25 @@ However, there are some general configuration details you should be aware of in 
 [[getting-started-cloudfoundry-general-configuration]]
 === General Configuration
 
-NOTE: You must use a unique name for your app. An application with the same name in the same organization causes your
-deployment to fail.
+NOTE: You must use a unique name for your app. An application with the same name in the same organization causes your deployment to fail.
 
-NOTE: The recommended minimum memory setting for the server is 2G. Also, to push apps to PCF and obtain
-application property metadata, the server downloads applications to a Maven repository hosted on the local disk. While
-you can specify up to 2G as a typical maximum value for disk space on a PCF installation, you can increase this to
-10G. Read the xref:getting-started-maximum-disk-quota-configuration[maximum disk quota] section for information on
-how to configure this PCF property. Also, the Data Flow server itself implements a Last-Recently-Used algorithm to
-free disk space when it falls below a low-water-mark value.
+NOTE: The recommended minimum memory setting for the server is 2G. Also, to push apps to PCF and obtain application property metadata, the server downloads applications to a Maven repository hosted on the local disk.
+While you can specify up to 2G as a typical maximum value for disk space on a PCF installation, you can increase this to 10G.
+Read the xref:getting-started-maximum-disk-quota-configuration[maximum disk quota] section for information on how to configure this PCF property.
+Also, the Data Flow server itself implements a Last-Recently-Used algorithm to free disk space when it falls below a low-water-mark value.
 
-NOTE: If you are pushing to a space with multiple users (for example, on PWS), the route you chose for your application name may already be taken. You can use the `--random-route` option to avoid this when you push the server application.
+NOTE: If you are pushing to a space with multiple users (for example, on PWS), the route you chose for your application name may already be taken.
+You can use the `--random-route` option to avoid this when you push the server application.
 
-NOTE: By default, the https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-registry[application registry] in Spring Cloud Data Flow's Cloud Foundry server is empty. It is intentionally designed to let you have the flexibility of http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-stream-apps[choosing and registering] applications as you find appropriate for the given use-case requirement. Depending on the message-binder you choose, you can register between http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[RabbitMQ- or Apache Kafka-based] Maven artifacts.
+NOTE: By default, the https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-registry[application registry] in Spring Cloud Data Flow's Cloud Foundry server is empty.
+It is intentionally designed to let you have the flexibility of http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-stream-apps[choosing and registering] applications as you find appropriate for the given use-case requirement. Depending on the message-binder you choose, you can register between http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[RabbitMQ- or Apache Kafka-based] Maven artifacts.
 
 NOTE: If you need to configure multiple Maven repositories, a proxy, or authorization for a private repository, see link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#getting-started-maven-configuration[Maven Configuration].
 
 [[getting-started-cloudfoundry-deploying-using-env-vars]]
 === Deploying by Using Environment Variables
 
-The following configuration is for Pivotal Web Services. You need to fill in `\{org}`, `\{space}`,
-`\{email}` and `\{password}` before running these commands.
+The following configuration is for Pivotal Web Services. You need to fill in `\{org}`, `\{space}`, `\{email}` and `\{password}` before running these commands.
 
 ====
 [source]
@@ -168,20 +163,13 @@ cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES my_m
 cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_USERNAME {email}
 cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_PASSWORD {password}
 cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SKIP_SSL_VALIDATION false
+cf set-env dataflow-server SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI https://<skipper-host-name>/api
 ----
 ====
 
 [NOTE]
 =====
-If you are going to use Skipper to deploy Streams, deploy Skipper first and then configure the URI location where the Skipper server runs and set the server to be in `skipper` mode. The following example shows how to do so:
-
-====
-[source]
-----
-cf set-env dataflow-server SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI https://<skipper-host-name>/api
-cf set-env dataflow-server SPRING_CLOUD_DATAFLOW_FEATURES_SKIPPER_ENABLED true
-----
-====
+Deploy Skipper first and then configure the URI location where the Skipper server runs.
 =====
 
 The Spring Cloud Data Flow server does not have any default remote maven repository configured.
@@ -196,11 +184,10 @@ cf set-env dataflow-server SPRING_APPLICATION_JSON '{"maven": { "remote-reposito
 where `repo1` is the alias name for the remote repository
 ====
 
-WARNING: Only set 'Skip SSL Validation' to true if you run on a Cloud Foundry instance using self-signed
-certificates (for example, in development). Do not use self-signed certificates for production.
+WARNING: Only set 'Skip SSL Validation' to true if you run on a Cloud Foundry instance using self-signed certificates (for example, in development).
+Do not use self-signed certificates for production.
 
-NOTE: If you are deploying in an environment that requires you to sign on using the Pivotal Single Sign-On Service,
-see <<getting-started-security-cloud-foundry>> for information on how to configure the server.
+NOTE: If you are deploying in an environment that requires you to sign on using the Pivotal Single Sign-On Service, see <<getting-started-security-cloud-foundry>> for information on how to configure the server.
 
 You can now issue a `cf push` command and reference the Data Flow server .jar file, as the following example shows:
 
@@ -216,8 +203,7 @@ cf bind-service dataflow-server my_mysql
 [[getting-started-cloudfoundry-deploying-using-manifest]]
 === Deploying by Using a Manifest
 
-As an alternative to setting environment variables with the `cf set-env` command, you can curate all the relevant env-var's
-in a `manifest.yml` file and use the `cf push` command to provision the server.
+As an alternative to setting environment variables with the `cf set-env` command, you can curate all the relevant env-var's in a `manifest.yml` file and use the `cf push` command to provision the server.
 
 The following example template provisions the server on PCFDev:
 
@@ -243,6 +229,7 @@ applications:
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES: rabbit
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES: mysql
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SKIP_SSL_VALIDATION: true
+    SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI: https://<skipper-host-name>/api
     SPRING_APPLICATION_JSON: '{"maven": { "remote-repositories": { "repo1": { "url": "https://repo.spring.io/libs-release"} } } }'
 services:
 - mysql
@@ -251,21 +238,10 @@ services:
 
 [NOTE]
 =====
-If you are going to use `Skipper` to deploy Streams, deploy Skipper first and then configure the URI location where the Skipper server runs and set the feature toggle to use skipper, as the following example shows:
-
-====
-[source,yml]
-----
-applications:
-  env:
-    SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI: https://<skipper-host-name>/api
-    SPRING_CLOUD_DATAFLOW_FEATURES_SKIPPER_ENABLED: true
-----
-====
+Deploy Skipper first and then configure the URI location where the Skipper server runs.
 =====
 
-Once you are ready with the relevant properties in this file, you can issue a `cf push` command from the directory where
-this file is stored.
+Once you are ready with the relevant properties in this file, you can issue a `cf push` command from the directory where this file is stored.
 
 [[getting-started-cloudfoundry-on-local]]
 == Local Installation
@@ -288,28 +264,22 @@ export SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES=rabbit
 # Note however that when the *server* is running locally, it can't access that db
 # task related commands that show executions won't work then
 export SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES=my_mysql
+export SKIPPER_CLIENT_HOST https://<skipper-host-name>/api
 ----
 ====
 
 You need to fill in `\{org}`, `\{space}`, `\{email}` and `\{password}` before running these commands.
 
-WARNING: Only set 'Skip SSL Validation' to true if you run on a Cloud Foundry instance using self-signed
-certificates (for example, in development). Do not use self-signed certificates for production.
+WARNING: Only set 'Skip SSL Validation' to true if you run on a Cloud Foundry instance using self-signed certificates (for example, in development).
+Do not use self-signed certificates for production.
 
 [NOTE]
 =====
-If you are going to use `Skipper` to deploy Streams, deploy Skipper first and then configure the URI location of where the Skipper server is running and enable the Skipper feature toggle.
-
-====
-[source]
-----
-export SKIPPER_CLIENT_HOST https://<skipper-host-name>/api
-export SPRING_CLOUD_DATAFLOW_FEATURES_SKIPPER_ENABLED true
-----
-====
+Deploy Skipper first and then configure the URI location of where the Skipper server is running.
 =====
 
-NOTE: Since Skipper is a Spring Boot application, you can also pass the configuration properties as command line options instead of environment variables. For example, `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES` becomes `--spring.cloud.deployer.cloudfoundry.stream.services`.
+NOTE: Since Skipper is a Spring Boot application, you can also pass the configuration properties as command line options instead of environment variables.
+For example, `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES` becomes `--spring.cloud.deployer.cloudfoundry.stream.services`.
 
 Now we are ready to start the server application, as follows:
 
@@ -320,14 +290,12 @@ java -jar spring-cloud-dataflow-server-cloudfoundry-{project-version}.jar
 ----
 ====
 
-TIP: All other parameterization options that were available when running the server on Cloud Foundry are
-still available. This is particularly true for xref:configuring-defaults[configuring defaults] for applications. To use them,
-substitute `cf set-env` syntax with `export`.
+TIP: All other parameterization options that were available when running the server on Cloud Foundry are still available.
+This is particularly true for xref:configuring-defaults[configuring defaults] for applications. To use them, substitute `cf set-env` syntax with `export`.
 
 [[getting-started-data-flow-shell]]
 == Data Flow Shell
-Launching the Data Flow shell requires that you specify the appropriate data flow server mode.
-The following example shows how to start the Data Flow Shell for the Data Flow server running in `classic` mode:
+The following example shows how to start the Data Flow Shell:
 
 ====
 [source,bash,subs=attributes]
@@ -339,8 +307,8 @@ $ java -jar spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 [[getting-started-deploying-streams]]
 == Deploying Streams
 
-By default, the application registry is empty. If you would like to register all out-of-the-box stream applications
-built with the RabbitMQ binder in bulk, run the following command:
+By default, the application registry is empty.
+If you would like to register all out-of-the-box stream applications built with the RabbitMQ binder in bulk, run the following command:
 
 ====
 [source]
@@ -349,25 +317,25 @@ dataflow:>app import --uri http://bit.ly/Darwin-SR1-stream-applications-rabbit-m
 ----
 ====
 
-For more details, review how to
-xref:spring-cloud-dataflow-register-apps[register applications].
+For more details, review how to xref:spring-cloud-dataflow-register-apps[register applications].
 
-You have two options for deploying Streams: the "`traditional`" way that Data Flow has always used and a new way that delegates to the Skipper server. Deploying by using Skipper lets you update and rollback the streams, while the traditional way does not.
+Data Flow delegates the Streams deployment to Skipper which provide support for features such as Streams update and rollback.
 
-=== Creating Streams without Skipper
+=== Creating Streams
 
-The following example shows how to create a simple stream with an HTTP source and a log sink:
+NOTE: Make sure the Skipper server is deployed and have configured the Data Flow server's `SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI` property to reference the Skipper server.
+
+The following example shows how to create and deploy a stream:
 
 ====
 [source]
 ----
-dataflow:> stream create --name httptest --definition "http | log" --deploy
+dataflow:> stream create --name httptest --definition "http | log"
+dataflow:> stream deploy --name httptest --platformName pws
 ----
 ====
 
-NOTE: You need to wait a little while until the applications are actually deployed
-before posting data. Tail the log file for each application to verify that
-the application has started.
+NOTE: You need to wait a little while until the applications are actually deployed before posting data. Tail the log file for each application to verify that the application has started.
 
 Now you can post some data. The URL is unique to your deployment. The following example shows how to post data:
 
@@ -380,35 +348,19 @@ dataflow:> http post --target http://dataflow-AxwwAhK-httptest-http.cfapps.io --
 
 Now you can see whether `hello world` is in the log files for the `log` application.
 
-=== Creating Streams with Skipper
-
-This section assumes you have deployed Skipper and have configured the Data Flow server's `SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI` property to reference the Skipper server.
-
-The following example shows how to create and deploy a stream with Skipper:
-
-====
-[source]
-----
-dataflow:> stream create --name httptest --definition "http | log"
-dataflow:> stream deploy --name httptest --platformName pws
-----
-====
-
-Now you can see whether `hello world` is in the log files for the `log` application.
-
 NOTE: Skipper includes the concept of link:https://docs.spring.io/spring-cloud-skipper/docs/current/reference/htmlsingle/#platforms[platforms],
-so it is important to define the "`accounts`" based on the project preferences. In the preceding YAML file, the accounts map
-to `pws` as the platform. You can modify this, and you can have any number of platform definitions.
+so it is important to define the "`accounts`" based on the project preferences.
+In the preceding YAML file, the accounts map to `pws` as the platform. You can modify this, and you can have any number of platform definitions.
 The https://docs.spring.io/spring-cloud-skipper/docs/current/reference/htmlsingle/[Spring Cloud Skipper reference guide] has more details.
 
 
-You can read more about the general features of using Skipper to deploy streams in the <<spring-cloud-dataflow-stream-lifecycle-skipper>> section and how to upgrade a streams in the <<spring-cloud-dataflow-stream-lifecycle-skipper-update>> section.
+You can read more about the general features of using Skipper to deploy streams in the <<spring-cloud-dataflow-stream-lifecycle>> section and how to upgrade a streams in the <<spring-cloud-dataflow-stream-lifecycle-update>> section.
 
 [[streams-using-skipper]]
-== Deploying Streams by Using Skipper
+== Deploying Streams
 
-This section proceeds with the assumption that Spring Cloud Data Flow, Spring Cloud Skipper, RDBMS, and your desired messaging
-middleware are all running in PWS. The following listing shows the apps running in a sample org and space:
+This section proceeds with the assumption that Spring Cloud Data Flow, Spring Cloud Skipper, RDBMS, and your desired messaging middleware are all running in PWS.
+The following listing shows the apps running in a sample org and space:
 
 ====
 [source,console,options=nowrap]
@@ -423,12 +375,12 @@ dataflow-server              started           1/1         1G       1G     dataf
 ----
 ====
 
-The following example shows how to start the Data Flow Shell for the Data Flow server running in `skipper` mode:
+The following example shows how to start the Data Flow Shell for the Data Flow server:
 
 ====
 [source,bash,subs=attributes]
 ----
-$ java -jar spring-cloud-dataflow-shell-{dataflow-project-version}.jar --dataflow.mode=skipper
+$ java -jar spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 ----
 ====
 
@@ -459,8 +411,8 @@ dataflow:>stream platform-list
 ----
 ====
 
-We start by deploying a stream with the `time-source` pointing to `1.2.0.RELEASE` and `log-sink` pointing
-to `1.1.0.RELEASE`. The goal is to perform a rolling upgrade of the `log-sink` application to `1.2.0.RELEASE`.
+We start by deploying a stream with the `time-source` pointing to `1.2.0.RELEASE` and `log-sink` pointing to `1.1.0.RELEASE`.
+The goal is to perform a rolling upgrade of the `log-sink` application to `1.2.0.RELEASE`.
 
 ====
 [source,console,options=nowrap]
@@ -652,9 +604,8 @@ dataflow-server              started           1/1         1G       1G     dataf
 ----
 ====
 
-NOTE: There are two versions of the `log-sink` applications. The `ticker-314-log-v1` application instance is going down
-(route already removed) and the newly spawned `ticker-314-log-v2` application is bootstrapping. The version number is incremented and
-the version-number (`v2`) is included in the new application name.
+NOTE: There are two versions of the `log-sink` applications. The `ticker-314-log-v1` application instance is going down (route already removed) and the newly spawned `ticker-314-log-v2` application is bootstrapping.
+The version number is incremented and the version-number (`v2`) is included in the new application name.
 
 . Once the new application is up and running, you can verify the logs, as the following example shows:
 
@@ -670,7 +621,9 @@ $ cf logs ticker-314-log-v2
 ----
 ====
 
-Now you can look at the updated package manifest persisted in Skipper. You should now be seeing `log-sink` at 1.2.0.RELEASE. The following example shows the command to use and its output:
+Now you can look at the updated package manifest persisted in Skipper.
+You should now be seeing `log-sink` at 1.2.0.RELEASE.
+The following example shows the command to use and its output:
 
 ====
 [source,yml,options=nowrap]
@@ -739,7 +692,8 @@ dataflow:>stream history --name ticker-314
 ----
 ====
 
-Rolling-back to the previous version is just a command away. The following example shows how to do so and the resulting output:
+Rolling-back to the previous version is just a command away.
+The following example shows how to do so and the resulting output:
 
 ====
 [source,console,options=nowrap]
@@ -792,10 +746,7 @@ dataflow:>task launch mytask
 ----
 ====
 
-You will see the year (`2018` at the time of this writing) printed in the logs. The execution status of the task is stored
-in the database, and you can retrieve information about the task execution by using the
-`task execution list` and `task execution status --id <ID_OF_TASK>` shell commands or though the Data Flow UI.
+You will see the year (`2018` at the time of this writing) printed in the logs. The execution status of the task is stored in the database, and you can retrieve information about the task execution by using the `task execution list` and `task execution status --id <ID_OF_TASK>` shell commands or though the Data Flow UI.
 
-NOTE: The current underlying PCF task capabilities are considered experimental for PCF version
-versions less than 1.9.  See http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#enable-disable-specific-features[Feature Togglers]
-for how to disable task support in Data Flow.
+NOTE: The current underlying PCF task capabilities are considered experimental for PCF version versions less than 1.9.
+See http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#enable-disable-specific-features[Feature Togglers] for how to disable task support in Data Flow.

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -31,7 +31,7 @@ cf create-service rediscloud 30mb redis
 === Provision a Rabbit Service Instance on Cloud Foundry
 RabbitMQ is used as a messaging middleware between streaming apps and is bound to each deployed streaming app.
 Apache Kafka is the other option.
-We can use the `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES` setting in Data Flow configuration or use the `SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_SERVICES` setting in Skipper, which automatically binds RabbitMQ to the deployed streaming applications.
+We can use the `SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_SERVICES` setting in `Skipper Server` configuration which automatically binds RabbitMQ to the deployed streaming applications.
 
 You can use `cf marketplace` to discover which plans are available to you, depending on the details of your Cloud Foundry setup.
 For example, you can use link:https://run.pivotal.io/[Pivotal Web Services]:
@@ -158,7 +158,6 @@ cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_URL https://api.ru
 cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_ORG {org}
 cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SPACE {space}
 cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_DOMAIN cfapps.io
-cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES rabbit
 cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES my_mysql
 cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_USERNAME {email}
 cf set-env dataflow-server SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_PASSWORD {password}
@@ -226,7 +225,6 @@ applications:
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_DOMAIN: local.pcfdev.io
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_USERNAME: admin
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_PASSWORD: admin
-    SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES: rabbit
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_TASK_SERVICES: mysql
     SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SKIP_SSL_VALIDATION: true
     SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI: https://<skipper-host-name>/api
@@ -259,7 +257,6 @@ export SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_USERNAME={email}
 export SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_PASSWORD={password}
 export SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_SKIP_SSL_VALIDATION=false
 
-export SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES=rabbit
 # The following is for letting task apps write to their db.
 # Note however that when the *server* is running locally, it can't access that db
 # task related commands that show executions won't work then
@@ -277,9 +274,6 @@ Do not use self-signed certificates for production.
 =====
 Deploy Skipper first and then configure the URI location of where the Skipper server is running.
 =====
-
-NOTE: Since Skipper is a Spring Boot application, you can also pass the configuration properties as command line options instead of environment variables.
-For example, `SPRING_CLOUD_DEPLOYER_CLOUDFOUNDRY_STREAM_SERVICES` becomes `--spring.cloud.deployer.cloudfoundry.stream.services`.
 
 Now we are ready to start the server application, as follows:
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -4,7 +4,7 @@
 [[getting-started-requirements]]
 == System Requirements
 
-The Spring Cloud Data Flow server deploys streams (long-lived applications) and tasks (short-lived applications) to Cloud Foundry.
+The Spring Cloud Data Flow server deploys task tasks (short-lived applications) and via Skipper deploys streams (long-lived applications) to Cloud Foundry.
 The server is a lightweight Spring Boot application. It can run on Cloud Foundry or your laptop, but it is more common to run the server in Cloud Foundry.
 
 Spring Cloud Data Flow requires a few data services to perform streaming, task/batch processing, and analytics.
@@ -70,7 +70,7 @@ wget http://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/sp
 wget http://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 ----
 ====
-. Download http://cloud.spring.io/spring-cloud-skipper/[Skipper] to which Data Flow delegate Streams lifecycle operations such as deployment, upgrading and rolling.
+. Download http://cloud.spring.io/spring-cloud-skipper/[Skipper] to which Data Flow delegate Streams lifecycle operations such as deployment, upgrading and rolling back.
 The following example shows how to do so:
 +
 ====
@@ -369,7 +369,7 @@ dataflow-server              started           1/1         1G       1G     dataf
 ----
 ====
 
-The following example shows how to start the Data Flow Shell for the Data Flow server:
+The following example shows how to start the Data Flow shell for the Data Flow server:
 
 ====
 [source,bash,subs=attributes]

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
@@ -1,5 +1,5 @@
 = Spring Cloud Data Flow Server for Cloud Foundry
-Sabby Anandan; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hillert; Mark Pollack; Thomas Risberg; Marius Bogoevici; Josh Long; Michael Minella; David Turanski; Vinicius Carvalho; Jay Bryant; Glenn Renfro
+Sabby Anandan; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hillert; Mark Pollack; Thomas Risberg; Marius Bogoevici; Josh Long; Michael Minella; David Turanski; Vinicius Carvalho; Jay Bryant; Glenn Renfro; Christian Tzolov
 :doctype: book
 :toc: left
 :toclevels: 4


### PR DESCRIPTION
 - Remove classic-mode occurrences in the documentation and use the Skipper as a default and only Stream management option
 - Add skipper Uri to all SCDF configurations

Resolves #453