### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
-= Spring Cloud Data Flow Server for Cloud Foundry image:https://build.spring.io/plugins/servlet/wittified/build-status/SCD-CFBMASTER[Build Status, link=https://build.spring.io/browse/SCD-CFBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=ready&title=Ready[Stories in Ready, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry]
+= Spring Cloud Data Flow Server for Cloud Foundry image:https://build.spring.io/plugins/servlet/wittified/build-status/SCD-CFBMASTER[Build Status, link=https://build.spring.io/browse/SCD-CFBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=ready&title=Ready[Stories in Ready, link=https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry]
 
 This project provides support for deploying https://github.com/spring-cloud/spring-cloud-dataflow[Spring Cloud Data Flow]'s streaming and batch data pipelines to Cloud Foundry. It includes an implementation of Spring Cloud Data Flow's https://github.com/spring-cloud/spring-cloud-deployer[Deployer SPI] for Cloud Foundry.
 
-Please refer to the http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#index[reference documentation] on how to get started.
+Please refer to the https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#index[reference documentation] on how to get started.
 
 === NOTE: Spring Cloud Data Flow v2.0
 
@@ -12,7 +12,7 @@ That would mean, as a user, you don't need to pick different JARs or Docker-imag
 
 The other notable benefit to this approach is the ability to configure the single-server with multiple platform backends. The same server can be configured against Local, "n" number of Cloud Foundry `org/space` combinations, and as well against "n" number of Kubernetes clusters and the associated `namespace`. At the time of stream-deployment or task-launches, you would be able to pick-and-choose the platform where you want to orchestrate the deployment. It would further simplify and promote CI/CD practices for data pipelines.
 
-The http://docs.spring.io/spring-cloud-dataflow/docs/2.0.0.BUILD-SNAPSHOT/reference/htmlsingle/#getting-started[getting-started] steps for each platform remains mostly the same. One significant change is how Tasks are configured, as we are opening up the capability for Tasks to be launched across different platforms as well.
+The https://docs.spring.io/spring-cloud-dataflow/docs/2.0.0.BUILD-SNAPSHOT/reference/htmlsingle/#getting-started[getting-started] steps for each platform remains mostly the same. One significant change is how Tasks are configured, as we are opening up the capability for Tasks to be launched across different platforms as well.
 
 In summary, please DO NOT use the `master` branch of this repository; switch over to https://github.com/spring-cloud/spring-cloud-dataflow[Spring Cloud Data Flow] v2.0 instead. We intend to continue to support the Spring Cloud Data Flow's v1.x branch of CloudFoundry-server for a period of at least a year from the general availability of v2.0 GA release.
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/api-guide-link.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/api-guide-link.adoc
@@ -1,7 +1,7 @@
 // The API Guide asciidoc source file residing in SCDF core cannot be included here, because it depends on generated
 // REST Docs snippets that are not versioned (and are heavyweight to regenerate for each flavor). Hence, we do a
 // simple link to the correct SCDF core version:
-:spring-cloud-dataflow-docs-rest: http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/index.html#api-guide
+:spring-cloud-dataflow-docs-rest: https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/index.html#api-guide
 
 [[api-guide]]
 = REST API Guide

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/appendix.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/appendix.adoc
@@ -3,7 +3,7 @@
 
 Having trouble with Spring Cloud Data Flow? We'd like to help!
 
-* Ask a question. We monitor http://stackoverflow.com[stackoverflow.com] for questions tagged with http://stackoverflow.com/tags/spring-cloud-dataflow[`spring-cloud-dataflow`].
+* Ask a question. We monitor https://stackoverflow.com[stackoverflow.com] for questions tagged with https://stackoverflow.com/tags/spring-cloud-dataflow[`spring-cloud-dataflow`].
 * Report bugs with Spring Cloud Data Flow at https://github.com/spring-cloud/spring-cloud-dataflow/issues.
 * Report bugs with Spring Cloud Data Flow for Cloud Foundry at https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/issues.
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/building.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/building.adoc
@@ -52,13 +52,13 @@ $ ./mvnw package -DskipTests=true -P full -pl {project-artifactId} -am
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/cf-tasks.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/cf-tasks.adoc
@@ -28,7 +28,7 @@ following sections outline the process of creating, launching, destroying, and v
 
 Similar to streams, creating a task application is done by using the SCDF DSL or through the
 dashboard. To create a task definition in SCDF, you must either develop a task
-application or use one of the out-of-the-box link:http://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[task app-starters].
+application or use one of the out-of-the-box link:https://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[task app-starters].
 The maven coordinates of the task application should be registered in SCDF. For more
 details on how to register task applications, see link:https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-task-apps[Registering a Task Application]
 in the core docs.

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/configuration.adoc
@@ -122,7 +122,7 @@ sdataflow:>stream deploy foo --properties "deployer.http.cloudfoundry.domain=myd
 ----
 ====
 
-The preceding example binds the `http` app to the `http://myhost.mydomain.com/my-path` URL. Note that this
+The preceding example binds the `http` app to the `https://myhost.mydomain.com/my-path` URL. Note that this
 example shows *all* of the available customization options. In practice, you can use only one or two out of the three.
 
 [[configuration-docker-apps]]
@@ -314,7 +314,7 @@ The following example shows how to deploy the `http` health check type to an end
 [[configuration-app-resolution-options]]
 == Application Resolution Alternatives
 
-Though we highly recommend using Maven Repository for application link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-stream-apps[resolution and registration]
+Though we highly recommend using Maven Repository for application link:https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-stream-apps[resolution and registration]
 in Cloud Foundry, there might be situations where an alternative approach would make sense. The following alternative options
 could help you resolve applications when running on Cloud Foundry.
 
@@ -326,7 +326,7 @@ application with the name `http-source.jar` by using `--uri=http://<Route-To-Sta
 * The über-jar's can be hosted on any external server that's reachable over HTTP. They can be resolved from raw GitHub URIs
 as well. From the shell, you can, for example, register the app with the name `http-source.jar` by using `--uri=http://<Raw_GitHub_URI>/http-source.jar`.
 
-* link:http://docs.cloudfoundry.org/buildpacks/staticfile/index.html[Static Buildpack] support in Cloud Foundry is another
+* link:https://docs.cloudfoundry.org/buildpacks/staticfile/index.html[Static Buildpack] support in Cloud Foundry is another
 option. A similar HTTP resolution works on this model, too.
 
 * link:https://docs.cloudfoundry.org/devguide/services/using-vol-services.html[Volume Services] is another great option.
@@ -346,7 +346,7 @@ By default, the Data Flow server is unsecured and runs on an unencrypted HTTP co
 (as well as the Data Flow Dashboard) by enabling HTTPS and requiring clients to authenticate.
 For more details about securing the
 REST endpoints and configuring to authenticate against an OAUTH backend (UAA and SSO running on Cloud Foundry),
-see the security section from the core http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[reference guide]. You can configure the security details in `dataflow-server.yml` or pass them as environment variables through `cf set-env` commands.
+see the security section from the core https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[reference guide]. You can configure the security details in `dataflow-server.yml` or pass them as environment variables through `cf set-env` commands.
 
 [[getting-started-security-cloud-foundry]]
 === Authentication and Cloud Foundry
@@ -379,12 +379,12 @@ SECURITY_OAUTH2_RESOURCE_USERINFOURI: "${security.oauth2.resource.userInfoUri}"
 <1> It is important that the property `spring.cloud.dataflow.security.cf-use-uaa` is set to `false`
 
 Authorization is similarly supported for non-Cloud Foundry security scenarios.
-See the security section from the core Data Flow http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[reference guide].
+See the security section from the core Data Flow https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[reference guide].
 
 As the provisioning of roles can vary widely across environments, we by
 default assign all Spring Cloud Data Flow roles to users.
 
-You can customize this behavior by providing your own http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html[`AuthoritiesExtractor`].
+You can customize this behavior by providing your own https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html[`AuthoritiesExtractor`].
 
 The following example shows one possible approach to set the custom `AuthoritiesExtractor` on the `UserInfoTokenServices`:
 
@@ -448,7 +448,7 @@ The following JSON example shows how to create a security configuration:
 ====
 
 By default, the `spring.cloud.dataflow.security.cf-use-uaa`  property is set to `true`. This property activates a special
-http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html[`AuthoritiesExtractor`] called `CloudFoundryDataflowAuthoritiesExtractor`.
+https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html[`AuthoritiesExtractor`] called `CloudFoundryDataflowAuthoritiesExtractor`.
 
 If you do not use CloudFoundry UAA, you should set `spring.cloud.dataflow.security.cf-use-uaa` to `false`.
 
@@ -585,9 +585,9 @@ a configuration server to use the same capabilities.
 Similar to Spring Cloud Data Flow server, you can configure both the stream and task applications to resolve the centralized properties from the configuration server.
 Setting the `spring.cloud.config.uri` property for the deployed applications is a common way to bind to the configuration server.
 See the link:https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html#_spring_cloud_config_client[Spring Cloud Config Client] reference guide for more information.
-Since this property is likely to be used across all applications deployed by the Data Flow server, the Data Flow server's `spring.cloud.dataflow.applicationProperties.stream` property for stream applications and `spring.cloud.dataflow.applicationProperties.task` property for task applications can be used to pass the `uri` of the Config Server to each deployed stream or task application. See the section on http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-global-properties[common application properties] for more information.
+Since this property is likely to be used across all applications deployed by the Data Flow server, the Data Flow server's `spring.cloud.dataflow.applicationProperties.stream` property for stream applications and `spring.cloud.dataflow.applicationProperties.task` property for task applications can be used to pass the `uri` of the Config Server to each deployed stream or task application. See the section on https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-global-properties[common application properties] for more information.
 
-Note that, if you use applications from the link:http://cloud.spring.io/spring-cloud-stream-app-starters/[App Starters project], these applications already embed the `spring-cloud-services-starter-config-client` dependency.
+Note that, if you use applications from the link:https://cloud.spring.io/spring-cloud-stream-app-starters/[App Starters project], these applications already embed the `spring-cloud-services-starter-config-client` dependency.
 If you build your application from scratch and want to add the client side support for config server, you can add a dependency reference to the config server client library. The following snippet shows a Maven example:
 
 ====

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -12,7 +12,7 @@ You have two options when you provision Spring Cloud Data Flow and related servi
 
 * The simplest (and automated) method is to use the link:https://network.pivotal.io/products/p-dataflow[Spring Cloud Data Flow for PCF] tile.
 This is an opinionated tile for Pivotal Cloud Foundry.
-It automatically provisions the server and the required data services, thus simplifying the overall getting-started experience. You can read more about the installation link:http://docs.pivotal.io/scdf/[here].
+It automatically provisions the server and the required data services, thus simplifying the overall getting-started experience. You can read more about the installation link:https://docs.pivotal.io/scdf/[here].
 * Alternatively, you can provision all the components manually. The following section goes into the specifics of how to do so.
 
 === Provision a Redis Service Instance on Cloud Foundry
@@ -65,18 +65,18 @@ Starting with 2.0.x, the Data Flow Server requires a `Skipper` server for managi
 ====
 [source,yaml,subs=attributes]
 ----
-wget http://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-server-cloudfoundry/{project-version}/spring-cloud-dataflow-server-cloudfoundry-{project-version}.jar
+wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-server-cloudfoundry/{project-version}/spring-cloud-dataflow-server-cloudfoundry-{project-version}.jar
 
-wget http://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
+wget https://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 ----
 ====
-. Download http://cloud.spring.io/spring-cloud-skipper/[Skipper] to which Data Flow delegate Streams lifecycle operations such as deployment, upgrading and rolling back.
+. Download https://cloud.spring.io/spring-cloud-skipper/[Skipper] to which Data Flow delegate Streams lifecycle operations such as deployment, upgrading and rolling back.
 The following example shows how to do so:
 +
 ====
 [source,yaml,options=nowrap,subs=attributes]
 ----
-wget http://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-server/{skipper-version}/spring-cloud-skipper-server-{skipper-version}.jar
+wget https://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-server/{skipper-version}/spring-cloud-skipper-server-{skipper-version}.jar
 ----
 ====
 +
@@ -142,9 +142,9 @@ NOTE: If you are pushing to a space with multiple users (for example, on PWS), t
 You can use the `--random-route` option to avoid this when you push the server application.
 
 NOTE: By default, the https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-registry[application registry] in Spring Cloud Data Flow's Cloud Foundry server is empty.
-It is intentionally designed to let you have the flexibility of http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-stream-apps[choosing and registering] applications as you find appropriate for the given use-case requirement. Depending on the message-binder you choose, you can register between http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[RabbitMQ- or Apache Kafka-based] Maven artifacts.
+It is intentionally designed to let you have the flexibility of https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-stream-apps[choosing and registering] applications as you find appropriate for the given use-case requirement. Depending on the message-binder you choose, you can register between https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[RabbitMQ- or Apache Kafka-based] Maven artifacts.
 
-NOTE: If you need to configure multiple Maven repositories, a proxy, or authorization for a private repository, see link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#getting-started-maven-configuration[Maven Configuration].
+NOTE: If you need to configure multiple Maven repositories, a proxy, or authorization for a private repository, see link:https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#getting-started-maven-configuration[Maven Configuration].
 
 [[getting-started-cloudfoundry-deploying-using-env-vars]]
 === Deploying by Using Environment Variables
@@ -307,7 +307,7 @@ If you would like to register all out-of-the-box stream applications built with 
 ====
 [source]
 ----
-dataflow:>app import --uri http://bit.ly/Darwin-SR1-stream-applications-rabbit-maven
+dataflow:>app import --uri https://bit.ly/Darwin-SR1-stream-applications-rabbit-maven
 ----
 ====
 
@@ -336,7 +336,7 @@ Now you can post some data. The URL is unique to your deployment. The following 
 ====
 [source]
 ----
-dataflow:> http post --target http://dataflow-AxwwAhK-httptest-http.cfapps.io --data "hello world"
+dataflow:> http post --target https://dataflow-AxwwAhK-httptest-http.cfapps.io --data "hello world"
 ----
 ====
 
@@ -383,8 +383,8 @@ If the Data Flow Server and shell are not running on the same host, you can poin
 ====
 [source]
 ----
-server-unknown:>dataflow config server http://dataflow-server.cfapps.io
-Successfully targeted http://dataflow-server.cfapps.io
+server-unknown:>dataflow config server https://dataflow-server.cfapps.io
+Successfully targeted https://dataflow-server.cfapps.io
 dataflow:>
 ----
 ====
@@ -718,7 +718,7 @@ To run a simple task application, you can register all the out-of-the-box task a
 ====
 [source]
 ----
-dataflow:>app import --uri http://bit.ly/Dearborn-GA-task-applications-maven
+dataflow:>app import --uri https://bit.ly/Dearborn-GA-task-applications-maven
 ----
 ====
 
@@ -743,4 +743,4 @@ dataflow:>task launch mytask
 You will see the year (`2018` at the time of this writing) printed in the logs. The execution status of the task is stored in the database, and you can retrieve information about the task execution by using the `task execution list` and `task execution status --id <ID_OF_TASK>` shell commands or though the Data Flow UI.
 
 NOTE: The current underlying PCF task capabilities are considered experimental for PCF version versions less than 1.9.
-See http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#enable-disable-specific-features[Feature Togglers] for how to disable task support in Data Flow.
+See https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#enable-disable-specific-features[Feature Togglers] for how to disable task support in Data Flow.

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
@@ -11,7 +11,7 @@ Sabby Anandan; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hiller
 :sectanchors:
 
 
-:spring-cloud-stream-docs: http://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/index.html
+:spring-cloud-stream-docs: https://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/index.html
 :github-code: https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry
 
 ifdef::backend-html5[]

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/overview.adoc
@@ -4,14 +4,14 @@ Spring Cloud Data Flow is a cloud-native orchestration service for composable mi
 With Spring Cloud Data Flow, developers can create and orchestrate data pipelines for common use cases such as data ingest,
 real-time analytics, and data import/export.
 
-The Spring Cloud Data Flow architecture consists of a server that deploys http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#streams[Streams]
-and http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-task-overview[Tasks].
-Streams and Tasks are defined using a http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/_dsl_syntax.html[DSL]
-or visually through the browser based designer UI.  Streams and Tasks are based on http://cloud.spring.io/spring-cloud-stream/[Spring Cloud Stream]
-and http://cloud.spring.io/spring-cloud-task/[Spring Cloud Task] programming models respectively.
+The Spring Cloud Data Flow architecture consists of a server that deploys https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#streams[Streams]
+and https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-task-overview[Tasks].
+Streams and Tasks are defined using a https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/_dsl_syntax.html[DSL]
+or visually through the browser based designer UI.  Streams and Tasks are based on https://cloud.spring.io/spring-cloud-stream/[Spring Cloud Stream]
+and https://cloud.spring.io/spring-cloud-task/[Spring Cloud Task] programming models respectively.
 
 For more details about the core architecture components and the supported features, please review Spring Cloud Data Flow's
-http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/[core reference guide].
+https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/[core reference guide].
 There're several https://github.com/spring-cloud/spring-cloud-dataflow-samples[samples] available for reference.
 
 [[spring-cloud-stream-overview]]
@@ -22,15 +22,15 @@ to message brokers. It provides opinionated configuration of middleware from sev
 persistent publish-subscribe semantics, consumer groups, and partitions.
 
 For more details about the core framework components and the supported features, please review Spring Cloud Stream's
-http://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/[reference guide].
+https://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/[reference guide].
 
-There's a rich ecosystem of Spring Cloud Stream http://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle[Application-Starters]
+There's a rich ecosystem of Spring Cloud Stream https://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle[Application-Starters]
 that can be used either as standalone microservice applications or in Spring Cloud Data Flow. For convenience, we have
-generated RabbitMQ and Apache Kafka variants of these application-starters that are available for use from http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[Maven Repo]
+generated RabbitMQ and Apache Kafka variants of these application-starters that are available for use from https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[Maven Repo]
 and https://hub.docker.com/r/springcloudstream/[Docker Hub] as maven artifacts and docker images, respectively.
 
 Do you have a requirement to develop custom applications? No problem. Refer to this guide to create
-http://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle/#_creating_custom_artifacts[custom stream applications].
+https://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle/#_creating_custom_artifacts[custom stream applications].
 There're several https://github.com/spring-cloud/spring-cloud-stream-samples[samples] available for reference.
 
 [[spring-cloud-task-overview]]
@@ -40,9 +40,9 @@ Spring Cloud Task makes it easy to create short-lived microservices. We provide 
 processes to be executed on demand in a production environment.
 
 For more details about the core framework components and the supported features, please review Spring Cloud Task's
-http://docs.spring.io/spring-cloud-task/docs/{sct-core-version}/reference/htmlsingle/[reference guide].
+https://docs.spring.io/spring-cloud-task/docs/{sct-core-version}/reference/htmlsingle/[reference guide].
 
-There's a rich ecosystem of Spring Cloud Task http://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[Application-Starters]
+There's a rich ecosystem of Spring Cloud Task https://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[Application-Starters]
 that can be used either as standalone microservice applications or in Spring Cloud Data Flow. For convenience, the generated
-application-starters are available for use from http://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/[Maven Repo].
+application-starters are available for use from https://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/[Maven Repo].
 There are several https://github.com/spring-cloud/spring-cloud-task/tree/master/spring-cloud-task-samples[samples] available for reference.

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry (301) with 2 occurrences migrated to:  
  https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry ([https](https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry) result ReadTimeoutException).
* [ ] http://dataflow-server.cfapps.io (ReadTimeoutException) with 2 occurrences migrated to:  
  https://dataflow-server.cfapps.io ([https](https://dataflow-server.cfapps.io) result ReadTimeoutException).
* [ ] http://myhost.mydomain.com/my-path (UnknownHostException) with 1 occurrences migrated to:  
  https://myhost.mydomain.com/my-path ([https](https://myhost.mydomain.com/my-path) result UnknownHostException).
* [ ] http://dataflow-AxwwAhK-httptest-http.cfapps.io (404) with 1 occurrences migrated to:  
  https://dataflow-AxwwAhK-httptest-http.cfapps.io ([https](https://dataflow-AxwwAhK-httptest-http.cfapps.io) result 404).
* [ ] http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html ([https](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-skipper/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-skipper/ ([https](https://cloud.spring.io/spring-cloud-skipper/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-stream-app-starters/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-stream-app-starters/ ([https](https://cloud.spring.io/spring-cloud-stream-app-starters/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-stream/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-stream/ ([https](https://cloud.spring.io/spring-cloud-stream/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-task/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-task/ ([https](https://cloud.spring.io/spring-cloud-task/) result 200).
* [ ] http://docs.cloudfoundry.org/buildpacks/staticfile/index.html with 1 occurrences migrated to:  
  https://docs.cloudfoundry.org/buildpacks/staticfile/index.html ([https](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/ with 12 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/ ([https](https://docs.spring.io/spring-cloud-dataflow/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/2.0.0.BUILD-SNAPSHOT/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/2.0.0.BUILD-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-dataflow/docs/2.0.0.BUILD-SNAPSHOT/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-cloud-stream-app-starters/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream-app-starters/docs/ ([https](https://docs.spring.io/spring-cloud-stream-app-starters/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-stream/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream/docs/ ([https](https://docs.spring.io/spring-cloud-stream/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-task-app-starters/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-task-app-starters/docs/ ([https](https://docs.spring.io/spring-cloud-task-app-starters/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-task/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-task/docs/ ([https](https://docs.spring.io/spring-cloud-task/docs/) result 200).
* [ ] http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/ with 2 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/ ([https](https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/) result 200).
* [ ] http://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/ ([https](https://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/) result 200).
* [ ] http://stackoverflow.com with 1 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://stackoverflow.com/tags/spring-cloud-dataflow with 1 occurrences migrated to:  
  https://stackoverflow.com/tags/spring-cloud-dataflow ([https](https://stackoverflow.com/tags/spring-cloud-dataflow) result 200).
* [ ] http://bit.ly/Darwin-SR1-stream-applications-rabbit-maven with 1 occurrences migrated to:  
  https://bit.ly/Darwin-SR1-stream-applications-rabbit-maven ([https](https://bit.ly/Darwin-SR1-stream-applications-rabbit-maven) result 301).
* [ ] http://bit.ly/Dearborn-GA-task-applications-maven with 1 occurrences migrated to:  
  https://bit.ly/Dearborn-GA-task-applications-maven ([https](https://bit.ly/Dearborn-GA-task-applications-maven) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.pivotal.io/scdf/ with 1 occurrences migrated to:  
  https://docs.pivotal.io/scdf/ ([https](https://docs.pivotal.io/scdf/) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://repo.spring.io/ with 3 occurrences migrated to:  
  https://repo.spring.io/ ([https](https://repo.spring.io/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost:8761/eureka/ with 1 occurrences
* http://localhost:8888 with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences