### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundryDataFlowServerConfiguration.java
+++ b/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundryDataFlowServerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundryServerConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/config/CloudFoundryServerConfigurationProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/resource/LRUCleaningResourceLoader.java
+++ b/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/resource/LRUCleaningResourceLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/resource/LRUCleaningResourceLoaderBeanPostProcessor.java
+++ b/spring-cloud-dataflow-server-cloudfoundry-autoconfig/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/resource/LRUCleaningResourceLoaderBeanPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/common.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/epub.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html-multipage.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html-multipage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html-singlepage.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html-singlepage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/pdf.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/CloudFoundryDataFlowServer.java
+++ b/spring-cloud-dataflow-server-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/server/cloudfoundry/CloudFoundryDataFlowServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-cloudfoundry/src/test/java/org/springframework/cloud/dataflow/server/cloudfoundry/CloudFoundryDataFlowServerApplicationTests.java
+++ b/spring-cloud-dataflow-server-cloudfoundry/src/test/java/org/springframework/cloud/dataflow/server/cloudfoundry/CloudFoundryDataFlowServerApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 13 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).