### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
-= Spring Cloud Data Flow Server for Cloud Foundry image:https://build.spring.io/plugins/servlet/buildStatusImage/SCD-CFBMASTER[Build Status, link=https://build.spring.io/browse/SCD-CFBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=ready&title=Ready[Stories in Ready, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry]
+= Spring Cloud Data Flow Server for Cloud Foundry image:https://build.spring.io/plugins/servlet/buildStatusImage/SCD-CFBMASTER[Build Status, link=https://build.spring.io/browse/SCD-CFBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=ready&title=Ready[Stories in Ready, link=https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry]
 
 This project provides support for deploying https://github.com/spring-cloud/spring-cloud-dataflow[Spring Cloud Data Flow]'s streaming and batch data pipelines to Cloud Foundry. It includes an implementation of Spring Cloud Data Flow's https://github.com/spring-cloud/spring-cloud-deployer[Deployer SPI] for Cloud Foundry.
 
-Please refer to the http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#index[reference documentation] on how to get started.
+Please refer to the https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#index[reference documentation] on how to get started.
 
 
 === Contributing

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/building.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/building.adoc
@@ -52,13 +52,13 @@ $ ./mvnw package -DskipTests=true -P full -pl {project-artifactId} -am
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/cf-tasks.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/cf-tasks.adoc
@@ -27,7 +27,7 @@ Data Flow server and now are upgrading to the 1.1.x version.  You can find the m
 link:https://github.com/spring-cloud/spring-cloud-task/tree/1.1.0.RELEASE/spring-cloud-task-core/src/main/resources/org/springframework/cloud/task/migration[here]
 in the Spring Cloud Task Github repository.  The documentation for
 link:https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-services.html[Accessing Services with Diego SSH]
-and this link:http://pivotaljourney.blogspot.com/2016/05/connecting-gui-tool-to-mysql-service-in.html[blog entry]
+and this link:https://pivotaljourney.blogspot.com/2016/05/connecting-gui-tool-to-mysql-service-in.html[blog entry]
 for connecting a GUI tools to the MySQL Service in PCF should help you to update the schema.
 
 == Running Task Applications
@@ -48,7 +48,7 @@ following sections outline the process of creating, launching, destroying, and v
 
 Similar to streams, creating a task application is done via the SCDF DSL or through the
 dashboard. To create a task definition in SCDF, you've to either develop a task
-application or use one of the out-of-the-box link:http://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[task app-starters].
+application or use one of the out-of-the-box link:https://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[task app-starters].
 The maven coordinates of the task application should be registered in SCDF. For more
 details on how to register task applications, review <<_registering_a_task_application,register task applications>>
 section from the core docs.

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -12,7 +12,7 @@ mechanism can be used (passing program arguments, editing configuration files be
 link:https://github.com/spring-cloud/spring-cloud-config[Spring Cloud Config], using environment variables, etc.),
 although some may prove more practicable than others when running _on_ Cloud Foundry.
 
-NOTE: By default, the https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-registry[application registry] in Spring Cloud Data Flow's Cloud Foundry server is empty. It is intentionally designed to allow users to have the flexibility of http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/_dsl_syntax.html#_register_a_stream_app[choosing and registering] applications, as they find appropriate for the given use-case requirement. Depending on the message-binder of choice, users can register between http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[RabbitMQ or Apache Kafka] based maven artifacts.
+NOTE: By default, the https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-registry[application registry] in Spring Cloud Data Flow's Cloud Foundry server is empty. It is intentionally designed to allow users to have the flexibility of https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/_dsl_syntax.html#_register_a_stream_app[choosing and registering] applications, as they find appropriate for the given use-case requirement. Depending on the message-binder of choice, users can register between https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[RabbitMQ or Apache Kafka] based maven artifacts.
 
 === Provision a Redis service instance on Cloud Foundry
 Use `cf marketplace` to discover which plans are available to you, depending on the details of your Cloud Foundry setup.
@@ -51,8 +51,8 @@ It can also be used for tasks to persist execution history.
 
 [subs=attributes]
 ```
-wget http://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-server-cloudfoundry/{project-version}/spring-cloud-dataflow-server-cloudfoundry-{project-version}.jar
-wget http://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
+wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-server-cloudfoundry/{project-version}/spring-cloud-dataflow-server-cloudfoundry-{project-version}.jar
+wget https://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 ```
 
 === Running the Server
@@ -209,7 +209,7 @@ still available. This is particularly true for xref:configuring-defaults[configu
 substitute `cf set-env` syntax with `export`.
 
 NOTE: The current underlying PCF task capabilities are considered experimental for PCF version
-versions less than 1.9.  See http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/enable-disable-specific-features.html[Feature Togglers]
+versions less than 1.9.  See https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/enable-disable-specific-features.html[Feature Togglers]
 for how to disable task support in Data Flow.
 
 [[sample-manifest-teample]]
@@ -263,8 +263,8 @@ $ java -jar spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 ----
 
 ```
-server-unknown:>dataflow config server http://dataflow-server.cfapps.io
-Successfully targeted http://dataflow-server.cfapps.io
+server-unknown:>dataflow config server https://dataflow-server.cfapps.io
+Successfully targeted https://dataflow-server.cfapps.io
 dataflow:>
 ```
 
@@ -273,7 +273,7 @@ built with the RabbitMQ binder in bulk, you can with the following command. For 
 xref:spring-cloud-dataflow-register-apps[register applications].
 
 ```
-dataflow:>app import --uri http://bit.ly/Avogadro-GA-stream-applications-rabbit-maven
+dataflow:>app import --uri https://bit.ly/Avogadro-GA-stream-applications-rabbit-maven
 
 ```
 
@@ -303,18 +303,18 @@ the application has started.
 Now post some data. The URL will be unique to your deployment, the following is just an example
 [source]
 ----
-dataflow:> http post --target http://dataflow-AxwwAhK-httptest-http.cfapps.io --data "hello world"
+dataflow:> http post --target https://dataflow-AxwwAhK-httptest-http.cfapps.io --data "hello world"
 ----
 Look to see if `hello world` ended up in log files for the `log` application.
 
 To run a simple task application, you can register all the out-of-the-box task applications with the following command.
 
 ```
-dataflow:>app import --uri http://bit.ly/Addison-GA-task-applications-maven
+dataflow:>app import --uri https://bit.ly/Addison-GA-task-applications-maven
 
 ```
 
-Now create a simple link:http://docs.spring.io/spring-cloud-task-app-starters/docs/1.0.1.RELEASE/reference/html/_timestamp_task.html[timestamp] task.
+Now create a simple link:https://docs.spring.io/spring-cloud-task-app-starters/docs/1.0.1.RELEASE/reference/html/_timestamp_task.html[timestamp] task.
 
 ```
 dataflow:>task create mytask --definition "timestamp --format='yyyy'"
@@ -337,7 +337,7 @@ in the database and you can retrieve information about the task execution using 
 By default, the Data Flow server is unsecured and runs on an unencrypted HTTP connection. You can secure your REST endpoints,
 as well as the Data Flow Dashboard by enabling HTTPS and requiring clients to authenticate. More details about securing the
 REST endpoints and configuring to authenticate against an OAUTH backend (_i.e: UAA/SSO running on Cloud Foundry_), please
-review the security section from the core http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/getting-started-security.html[reference guide]. The security configurations can be configured in `dataflow-server.yml` or passed as environment variables through `cf set-env` commands.
+review the security section from the core https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/getting-started-security.html[reference guide]. The security configurations can be configured in `dataflow-server.yml` or passed as environment variables through `cf set-env` commands.
 
 [[getting-started-security-cloud-foundry]]
 === Authentication and Cloud Foundry
@@ -377,7 +377,7 @@ dataflow:>stream deploy foo --properties "app.http.spring.cloud.deployer.cloudfo
                                           app.http.spring.cloud.deployer.cloudfoundry.route-path=my-path"
 ----
 
-This would result in the `http` app being bound to the URL `http://myhost.mydomain.com/my-path`. Note that this is an
+This would result in the `http` app being bound to the URL `https://myhost.mydomain.com/my-path`. Note that this is an
 example showing *all* customization options available. One can of course only leverage one or two out of the three.
 
 == Configuration Reference
@@ -476,7 +476,7 @@ config-server to leverage the same capabilities. Let's review the integration st
 
 ==== Spring Cloud Data Flow and Spring Cloud Config Server
 
-* Download 1.4.x release of Spring Boot from http://start.spring.io
+* Download 1.4.x release of Spring Boot from https://start.spring.io
 * Add `spring-cloud-dataflow-server-cloudfoundry-autoconfig` dependency pointing to Spring Cloud Data Flow's Cloud Foundry link:https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/releases[release]
 * Add `@EnableDataFlowServer` to the downloaded application
 
@@ -521,9 +521,9 @@ The final über-jar is now ready to be deployed to Cloud Foundry. With this setu
 bound to config-server service on Cloud Foundry, we can successfully negotiate, read, and resolve centralized properties
 at the runtime.
 
-Follow the http://docs.pivotal.io/spring-cloud-services/config-server[documentation]
+Follow the https://docs.pivotal.io/spring-cloud-services/config-server[documentation]
 for Config Server for Pivotal Cloud Foundry. For more details, please refer to Spring Cloud Services
-http://docs.pivotal.io/spring-cloud-services/client-dependencies.html#config-server[client-dependencies documentation].
+https://docs.pivotal.io/spring-cloud-services/client-dependencies.html#config-server[client-dependencies documentation].
 
 ==== Stream, Task, and Spring Cloud Config Server
 Similar to Spring Cloud Data Flow server, it is also possible to configure both the stream and task applications to
@@ -531,7 +531,7 @@ resolve the centralized properties from config-server.
 
 Let's assume you'd like to read properties for `time-source` application from config-server.
 
-* Download the `time-source` application starter with "Rabbit binder starter" from http://start-scs.cfapps.io/
+* Download the `time-source` application starter with "Rabbit binder starter" from https://start-scs.cfapps.io/
 * Load the downloaded project in an IDE
 * Add `@Import(org.springframework.cloud.stream.app.time.source.TimeSourceConfiguration.class)` to import time-source's
 configuration properties
@@ -724,7 +724,7 @@ foo-time   started           1/1         1G       1G     foo-time.cfapps.io
 
 Let's assume you've to make an enhancement to update the "logger" to append extra text in every log statement.
 
-* Download the `Log Sink` application starter with "Rabbit binder starter" from http://start-scs.cfapps.io/
+* Download the `Log Sink` application starter with "Rabbit binder starter" from https://start-scs.cfapps.io/
 * Load the downloaded project in an IDE
 * Import the `LogSinkConfiguration.class`
 * Adapt the handler to add extra text: `loggingHandler.setLoggerName("TEST [" + this.properties.getName() + "]");`
@@ -833,7 +833,7 @@ foo-time   started           1/1         1G       1G     foo-time.cfapps.io
 foo-log-v2 started           1/1         1G       1G     foo-log-v2.cfapps.io
 ----
 
-NOTE: A comprehensive canary analysis along with rolling upgrades will be supported via http://www.spinnaker.io/[Spinnaker]
+NOTE: A comprehensive canary analysis along with rolling upgrades will be supported via https://www.spinnaker.io/[Spinnaker]
 in future releases.
 
 [[getting-started-maximum-disk-quota-configuration]]

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
@@ -8,7 +8,7 @@ Sabby Anandan; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hiller
 :icons: font
 :hide-uri-scheme:
 
-:spring-cloud-stream-docs: http://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/index.html
+:spring-cloud-stream-docs: https://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/index.html
 :github-code: https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry
 // ======================================================================================
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/overview.adoc
@@ -4,14 +4,14 @@ Spring Cloud Data Flow is a cloud-native orchestration service for composable mi
 With Spring Cloud Data Flow, developers can create and orchestrate data pipelines for common use cases such as data ingest,
 real-time analytics, and data import/export.
 
-The Spring Cloud Data Flow architecture consists of a server that deploys http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#streams[Streams]
-and http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-task-overview[Tasks].
-Streams and Tasks are defined using a http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/_dsl_syntax.html[DSL]
-or visually through the browser based designer UI.  Streams and Tasks are based on http://cloud.spring.io/spring-cloud-stream/[Spring Cloud Stream]
-and http://cloud.spring.io/spring-cloud-task/[Spring Cloud Task] programming models respectively.
+The Spring Cloud Data Flow architecture consists of a server that deploys https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#streams[Streams]
+and https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-task-overview[Tasks].
+Streams and Tasks are defined using a https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/_dsl_syntax.html[DSL]
+or visually through the browser based designer UI.  Streams and Tasks are based on https://cloud.spring.io/spring-cloud-stream/[Spring Cloud Stream]
+and https://cloud.spring.io/spring-cloud-task/[Spring Cloud Task] programming models respectively.
 
 For more details about the core architecture components and the supported features, please review Spring Cloud Data Flow's
-http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/[core reference guide].
+https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/[core reference guide].
 There're several https://github.com/spring-cloud/spring-cloud-dataflow-samples[samples] available for reference.
 
 [[spring-cloud-stream-overview]]
@@ -22,15 +22,15 @@ to message brokers. It provides opinionated configuration of middleware from sev
 persistent publish-subscribe semantics, consumer groups, and partitions.
 
 For more details about the core framework components and the supported features, please review Spring Cloud Stream's
-http://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/[reference guide].
+https://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/[reference guide].
 
-There's a rich ecosystem of Spring Cloud Stream http://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle[Application-Starters]
+There's a rich ecosystem of Spring Cloud Stream https://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle[Application-Starters]
 that can be used either as standalone microservice applications or in Spring Cloud Data Flow. For convenience, we have
-generated RabbitMQ and Apache Kafka variants of these application-starters that are available for use from http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[Maven Repo]
+generated RabbitMQ and Apache Kafka variants of these application-starters that are available for use from https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[Maven Repo]
 and https://hub.docker.com/r/springcloudstream/[Docker Hub] as maven artifacts and docker images, respectively.
 
 Do you have a requirement to develop custom applications? No problem. Refer to this guide to create
-http://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle/#_creating_custom_artifacts[custom stream applications].
+https://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle/#_creating_custom_artifacts[custom stream applications].
 There're several https://github.com/spring-cloud/spring-cloud-stream-samples[samples] available for reference.
 
 [[spring-cloud-task-overview]]
@@ -40,9 +40,9 @@ Spring Cloud Task makes it easy to create short-lived microservices. We provide 
 processes to be executed on demand in a production environment.
 
 For more details about the core framework components and the supported features, please review Spring Cloud Task's
-http://docs.spring.io/spring-cloud-task/{sct-core-version}/reference/htmlsingle/[reference guide].
+https://docs.spring.io/spring-cloud-task/{sct-core-version}/reference/htmlsingle/[reference guide].
 
-There's a rich ecosystem of Spring Cloud Task http://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[Application-Starters]
+There's a rich ecosystem of Spring Cloud Task https://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[Application-Starters]
 that can be used either as standalone microservice applications or in Spring Cloud Data Flow. For convenience, the generated
-application-starters are available for use from http://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/[Maven Repo].
+application-starters are available for use from https://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/[Maven Repo].
 There are several https://github.com/spring-cloud/spring-cloud-task/tree/master/spring-cloud-task-samples[samples] available for reference.

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://dataflow-server.cfapps.io (ReadTimeoutException) with 2 occurrences migrated to:  
  https://dataflow-server.cfapps.io ([https](https://dataflow-server.cfapps.io) result ReadTimeoutException).
* [ ] http://myhost.mydomain.com/my-path (UnknownHostException) with 1 occurrences migrated to:  
  https://myhost.mydomain.com/my-path ([https](https://myhost.mydomain.com/my-path) result UnknownHostException).
* [ ] http://dataflow-AxwwAhK-httptest-http.cfapps.io (404) with 1 occurrences migrated to:  
  https://dataflow-AxwwAhK-httptest-http.cfapps.io ([https](https://dataflow-AxwwAhK-httptest-http.cfapps.io) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-stream/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-stream/ ([https](https://cloud.spring.io/spring-cloud-stream/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-task/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-task/ ([https](https://cloud.spring.io/spring-cloud-task/) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/ with 7 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/ ([https](https://docs.spring.io/spring-cloud-dataflow/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-stream-app-starters/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream-app-starters/docs/ ([https](https://docs.spring.io/spring-cloud-stream-app-starters/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-stream/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream/docs/ ([https](https://docs.spring.io/spring-cloud-stream/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-task-app-starters/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-task-app-starters/docs/ ([https](https://docs.spring.io/spring-cloud-task-app-starters/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-task-app-starters/docs/1.0.1.RELEASE/reference/html/_timestamp_task.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-task-app-starters/docs/1.0.1.RELEASE/reference/html/_timestamp_task.html ([https](https://docs.spring.io/spring-cloud-task-app-starters/docs/1.0.1.RELEASE/reference/html/_timestamp_task.html) result 200).
* [ ] http://docs.spring.io/spring-cloud-task/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-task/ ([https](https://docs.spring.io/spring-cloud-task/) result 200).
* [ ] http://pivotaljourney.blogspot.com/2016/05/connecting-gui-tool-to-mysql-service-in.html with 1 occurrences migrated to:  
  https://pivotaljourney.blogspot.com/2016/05/connecting-gui-tool-to-mysql-service-in.html ([https](https://pivotaljourney.blogspot.com/2016/05/connecting-gui-tool-to-mysql-service-in.html) result 200).
* [ ] http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/ with 2 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/ ([https](https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/) result 200).
* [ ] http://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/ ([https](https://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/) result 200).
* [ ] http://start-scs.cfapps.io/ with 2 occurrences migrated to:  
  https://start-scs.cfapps.io/ ([https](https://start-scs.cfapps.io/) result 200).
* [ ] http://start.spring.io with 1 occurrences migrated to:  
  https://start.spring.io ([https](https://start.spring.io) result 200).
* [ ] http://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry with 2 occurrences migrated to:  
  https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry ([https](https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry) result 200).
* [ ] http://www.spinnaker.io/ with 1 occurrences migrated to:  
  https://www.spinnaker.io/ ([https](https://www.spinnaker.io/) result 200).
* [ ] http://bit.ly/Addison-GA-task-applications-maven with 1 occurrences migrated to:  
  https://bit.ly/Addison-GA-task-applications-maven ([https](https://bit.ly/Addison-GA-task-applications-maven) result 301).
* [ ] http://bit.ly/Avogadro-GA-stream-applications-rabbit-maven with 1 occurrences migrated to:  
  https://bit.ly/Avogadro-GA-stream-applications-rabbit-maven ([https](https://bit.ly/Avogadro-GA-stream-applications-rabbit-maven) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.pivotal.io/spring-cloud-services/client-dependencies.html with 1 occurrences migrated to:  
  https://docs.pivotal.io/spring-cloud-services/client-dependencies.html ([https](https://docs.pivotal.io/spring-cloud-services/client-dependencies.html) result 301).
* [ ] http://docs.pivotal.io/spring-cloud-services/config-server with 1 occurrences migrated to:  
  https://docs.pivotal.io/spring-cloud-services/config-server ([https](https://docs.pivotal.io/spring-cloud-services/config-server) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://repo.spring.io/ with 2 occurrences migrated to:  
  https://repo.spring.io/ ([https](https://repo.spring.io/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:9999/me with 1 occurrences
* http://127.0.0.1:9999/oauth/authorize with 1 occurrences
* http://127.0.0.1:9999/oauth/token with 1 occurrences
* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost:8761/eureka/ with 1 occurrences
* http://localhost:8888 with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences