### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
-= Spring Cloud Data Flow Server for Cloud Foundry image:https://build.spring.io/plugins/servlet/wittified/build-status/SCD-CFBMASTER[Build Status, link=https://build.spring.io/browse/SCD-CFBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=ready&title=Ready[Stories in Ready, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry]
+= Spring Cloud Data Flow Server for Cloud Foundry image:https://build.spring.io/plugins/servlet/wittified/build-status/SCD-CFBMASTER[Build Status, link=https://build.spring.io/browse/SCD-CFBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=ready&title=Ready[Stories in Ready, link=https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry]
 
 This project provides support for deploying https://github.com/spring-cloud/spring-cloud-dataflow[Spring Cloud Data Flow]'s streaming and batch data pipelines to Cloud Foundry. It includes an implementation of Spring Cloud Data Flow's https://github.com/spring-cloud/spring-cloud-deployer[Deployer SPI] for Cloud Foundry.
 
-Please refer to the http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#index[reference documentation] on how to get started.
+Please refer to the https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#index[reference documentation] on how to get started.
 
 
 === Contributing

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/api-guide-link.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/api-guide-link.adoc
@@ -1,7 +1,7 @@
 // The API Guide adoc source file residing in SCDF core can't be included here, because it depends on generated
 // REST Docs snippets that aren't versionned (and are heavyweight to regenerate for each flavor). Hence, we do a
 // simple link to the correct SCDF core version:
-:spring-cloud-dataflow-docs-rest: http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/index.html#api-guide
+:spring-cloud-dataflow-docs-rest: https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/index.html#api-guide
 
 [[api-guide]]
 = REST API Guide

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/appendix.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/appendix.adoc
@@ -5,8 +5,8 @@
 --
 Having trouble with Spring Cloud Data Flow, We'd like to help!
 
-* Ask a question - we monitor http://stackoverflow.com[stackoverflow.com] for questions
-  tagged with http://stackoverflow.com/tags/spring-cloud-dataflow[`spring-cloud-dataflow`].
+* Ask a question - we monitor https://stackoverflow.com[stackoverflow.com] for questions
+  tagged with https://stackoverflow.com/tags/spring-cloud-dataflow[`spring-cloud-dataflow`].
 * Report bugs with Spring Cloud Data Flow at https://github.com/spring-cloud/spring-cloud-dataflow/issues.
 * Report bugs with Spring Cloud Data Flow for Cloud Foundry at https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry/issues.
 --

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/building.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/building.adoc
@@ -52,13 +52,13 @@ $ ./mvnw package -DskipTests=true -P full -pl {project-artifactId} -am
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/cf-tasks.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/cf-tasks.adoc
@@ -21,7 +21,7 @@ Data Flow server and now are upgrading to the 1.1.x version.  You can find the m
 link:https://github.com/spring-cloud/spring-cloud-task/tree/1.1.0.RELEASE/spring-cloud-task-core/src/main/resources/org/springframework/cloud/task/migration[here]
 in the Spring Cloud Task Github repository.  The documentation for
 link:https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-services.html[Accessing Services with Diego SSH]
-and this link:http://pivotaljourney.blogspot.com/2016/05/connecting-gui-tool-to-mysql-service-in.html[blog entry]
+and this link:https://pivotaljourney.blogspot.com/2016/05/connecting-gui-tool-to-mysql-service-in.html[blog entry]
 for connecting a GUI tools to the MySQL Service in PCF should help you to update the schema.
 
 == Running Task Applications
@@ -42,7 +42,7 @@ following sections outline the process of creating, launching, destroying, and v
 
 Similar to streams, creating a task application is done via the SCDF DSL or through the
 dashboard. To create a task definition in SCDF, you've to either develop a task
-application or use one of the out-of-the-box link:http://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[task app-starters].
+application or use one of the out-of-the-box link:https://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[task app-starters].
 The maven coordinates of the task application should be registered in SCDF. For more
 details on how to register task applications, review <<_registering_a_task_application,register task applications>>
 section from the core docs.

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/configuration.adoc
@@ -104,7 +104,7 @@ sdataflow:>stream deploy foo --properties "deployer.http.cloudfoundry.domain=myd
                                           deployer.http.cloudfoundry.route-path=my-path"
 ----
 
-This would result in the `http` app being bound to the URL `http://myhost.mydomain.com/my-path`. Note that this is an
+This would result in the `http` app being bound to the URL `https://myhost.mydomain.com/my-path`. Note that this is an
 example showing *all* customization options available. One can of course only leverage one or two out of the three.
 
 [[configuration-docker-apps]]
@@ -261,7 +261,7 @@ spring.cloud.dataflow.server.cloudfoundry.freeDiskSpacePercentage=25
 
 [[configuration-app-resolution-options]]
 == Application Resolution Alternatives
-Though we highly recommend using Maven Repository for application link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-stream-apps[resolution and registration]
+Though we highly recommend using Maven Repository for application link:https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-stream-apps[resolution and registration]
 in Cloud Foundry, there might be situations where an alternative approach would make sense. Following alternative options
 could come handy for resolving applications when running on Cloud Foundry.
 
@@ -273,7 +273,7 @@ app with the name `http-source.jar` via `--uri=http://<Route-To-StaticApp>/http-
 * The Über-jar's can be hosted on any external server that's reachable via HTTP. They can be resolved from raw GitHub URIs
 as well. From the Shell, you can, for example, register the app with the name `http-source.jar` via `--uri=http://<Raw_GitHub_URI>/http-source.jar`.
 
-* link:http://docs.cloudfoundry.org/buildpacks/staticfile/index.html[Static Buildpack ]support in Cloud Foundry is another
+* link:https://docs.cloudfoundry.org/buildpacks/staticfile/index.html[Static Buildpack ]support in Cloud Foundry is another
 option. A similar HTTP resolution will work on this model, too.
 
 * link:https://docs.cloudfoundry.org/devguide/services/using-vol-services.html[Volume Services] is another great option.
@@ -288,7 +288,7 @@ By default, the Data Flow server is unsecured and runs on an unencrypted HTTP co
 as well as the Data Flow Dashboard by enabling HTTPS and requiring clients to authenticate.
 For more details about securing the
 REST endpoints and configuring to authenticate against an OAUTH backend (_i.e: UAA/SSO running on Cloud Foundry_), please
-review the security section from the core http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[reference guide]. The security configurations can be configured in `dataflow-server.yml` or passed as environment variables through `cf set-env` commands.
+review the security section from the core https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[reference guide]. The security configurations can be configured in `dataflow-server.yml` or passed as environment variables through `cf set-env` commands.
 
 [[getting-started-security-cloud-foundry]]
 === Authentication and Cloud Foundry
@@ -309,12 +309,12 @@ Simply bind the _Pivotal Single Sign-On Service_ to your Data Flow Server app an
 Single Sign-On (SSO) via OAuth2 will be enabled by default.
 
 Authorization is similarly support as for non-Cloud Foundry security scenarios.
-Please refer to the security section from the core Data Flow http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[reference guide].
+Please refer to the security section from the core Data Flow https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[reference guide].
 
 As the provisioning of roles can vary widely across environments, we assign by
 default all Spring Cloud Data Flow roles to users.
 
-This can be customized by providing your own http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html[AuthoritiesExtractor].
+This can be customized by providing your own https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html[AuthoritiesExtractor].
 
 One possible approach to set the custom `AuthoritiesExtractor` on the `UserInfoTokenServices` could be this:
 
@@ -371,7 +371,7 @@ property.
 
 By default, the property `spring.cloud.dataflow.security.cf-use-uaa` is set to `true`. This property will activate a special
 
-http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html[AuthoritiesExtractor] **CloudFoundryDataflowAuthoritiesExtractor**.
+https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html[AuthoritiesExtractor] **CloudFoundryDataflowAuthoritiesExtractor**.
 
 If CloudFoundry UAA is not used, then make sure to set `spring.cloud.dataflow.security.cf-use-uaa` to `false`.
 
@@ -503,7 +503,7 @@ See the link:https://cloud.spring.io/spring-cloud-config/spring-cloud-config.htm
 Since this property is likely to be used across all applications deployed by the Data Flow server, the Data Flow Server's property `spring.cloud.dataflow.applicationProperties.stream` for stream apps and `spring.cloud.dataflow.applicationProperties.task` for task apps can be used to pass the `uri` of the Config Server to each deployed stream or task application.  Refer to the section on Common application properties for more information.
 
 
-If you're using applications from the link:http://cloud.spring.io/spring-cloud-stream-app-starters/[App Starters project], note that these applications already embed the `spring-cloud-services-starter-config-client` dependency.
+If you're using applications from the link:https://cloud.spring.io/spring-cloud-stream-app-starters/[App Starters project], note that these applications already embed the `spring-cloud-services-starter-config-client` dependency.
 If you're building your application from scratch and want to add the client side support for config server, simply add a reference dependency reference to the config server client library.  A maven example snippet follows:
 
 [source,xml]

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/getting-started.adoc
@@ -14,7 +14,7 @@ two options to provisioning Spring Cloud Data Flow and related services on Cloud
 - The simplest and the automated method is to use the link:https://network.pivotal.io/products/p-dataflow[Spring Cloud Data Flow for PCF]
 tile. This is an opinionated tile for Pivotal Cloud Foundry and the tile automatically provisions the server and the required
 data services, thus simplifying the overall getting-started experience. You can read more about the installation
-link:http://docs.pivotal.io/scdf/[here].
+link:https://docs.pivotal.io/scdf/[here].
 - Alternatively, you can provision all the components manually. The following section goes into the specifics on how it
 is done.
 
@@ -62,15 +62,15 @@ By default, the `classic` mode is enabled.
 +
 [subs=attributes]
 ```
-wget http://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-server-cloudfoundry/{project-version}/spring-cloud-dataflow-server-cloudfoundry-{project-version}.jar
+wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-server-cloudfoundry/{project-version}/spring-cloud-dataflow-server-cloudfoundry-{project-version}.jar
 
-wget http://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
+wget https://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 ```
-. Optionally, download http://cloud.spring.io/spring-cloud-skipper/[Skipper] if you want the added features of upgrading and rolling back Streams since Data Flow delegates to Skipper for those features.
+. Optionally, download https://cloud.spring.io/spring-cloud-skipper/[Skipper] if you want the added features of upgrading and rolling back Streams since Data Flow delegates to Skipper for those features.
 +
 [source,yaml,options=nowrap,subs=attributes]
 ----
-wget http://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-server/{skipper-version}/spring-cloud-skipper-server-{skipper-version}.jar
+wget https://repo.spring.io/{skipper-version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-server/{skipper-version}/spring-cloud-skipper-server-{skipper-version}.jar
 ----
 +
 Push Skipper to Cloud Foundry only if you want to run Spring Cloud Data Flow server in `skipper` mode.  Here is a sample
@@ -134,9 +134,9 @@ free disk space when it falls below a low water mark value.
 NOTE: If you are pushing to a space with multiple users, for example on PWS, there may already be a route taken for the
 applicaiton name you have chosen. You can use the options `--random-route` to avoid this when pushing the server application.
 
-NOTE: By default, the https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-registry[application registry] in Spring Cloud Data Flow's Cloud Foundry server is empty. It is intentionally designed to allow users to have the flexibility of http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-stream-apps[choosing and registering] applications, as they find appropriate for the given use-case requirement. Depending on the message-binder of choice, users can register between http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[RabbitMQ or Apache Kafka] based maven artifacts.
+NOTE: By default, the https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-registry[application registry] in Spring Cloud Data Flow's Cloud Foundry server is empty. It is intentionally designed to allow users to have the flexibility of https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-dataflow-register-stream-apps[choosing and registering] applications, as they find appropriate for the given use-case requirement. Depending on the message-binder of choice, users can register between https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[RabbitMQ or Apache Kafka] based maven artifacts.
 
-NOTE: If you need to configure multiple Maven repositories, a proxy, or authorization for a private repository, see link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#getting-started-maven-configuration[Maven Configuration].
+NOTE: If you need to configure multiple Maven repositories, a proxy, or authorization for a private repository, see link:https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#getting-started-maven-configuration[Maven Configuration].
 
 [[getting-started-cloudfoundry-deploying-using-env-vars]]
 === Deploying using environment variables
@@ -300,7 +300,7 @@ built with the RabbitMQ binder in bulk, you can with the following command. For 
 xref:spring-cloud-dataflow-register-apps[register applications].
 +
 ```
-dataflow:>app import --uri http://bit.ly/Celsius-SR1-stream-applications-rabbit-maven
+dataflow:>app import --uri https://bit.ly/Celsius-SR1-stream-applications-rabbit-maven
 ```
 +
 There are two options for deploying Streams. The "traditional" way that Data Flow has always used and a new way that delegates to the Skipper server. Deploying using Skipper will enable you to update and rollback the streams while the traditional way will not.
@@ -322,7 +322,7 @@ Now post some data. The URL will be unique to your deployment, the following is 
 +
 [source]
 ----
-dataflow:> http post --target http://dataflow-AxwwAhK-httptest-http.cfapps.io --data "hello world"
+dataflow:> http post --target https://dataflow-AxwwAhK-httptest-http.cfapps.io --data "hello world"
 ----
 Look to see if `hello world` ended up in log files for the `log` application.
 +
@@ -373,8 +373,8 @@ $ java -jar spring-cloud-dataflow-shell-{dataflow-project-version}.jar --dataflo
 ----
 If the Data Flow Server and shell are not running on the same host, point the shell to the Data Flow server URL:
 ```
-server-unknown:>dataflow config server http://dataflow-server.cfapps.io
-Successfully targeted http://dataflow-server.cfapps.io
+server-unknown:>dataflow config server https://dataflow-server.cfapps.io
+Successfully targeted https://dataflow-server.cfapps.io
 dataflow:>
 ```
 Alternatively, pass in the command line option `--dataflow.uri`.  The shell's command line option `--help` shows what options are available.
@@ -702,7 +702,7 @@ dataflow:>stream history --name ticker-314
 To run a simple task application, you can register all the out-of-the-box task applications with the following command.
 
 ```
-dataflow:>app import --uri http://bit.ly/Clark-GA-task-applications-maven
+dataflow:>app import --uri https://bit.ly/Clark-GA-task-applications-maven
 
 ```
 
@@ -723,6 +723,6 @@ in the database and you can retrieve information about the task execution using 
 `task execution list` and `task execution status --id <ID_OF_TASK>` or though the Data Flow UI.
 
 NOTE: The current underlying PCF task capabilities are considered experimental for PCF version
-versions less than 1.9.  See http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#enable-disable-specific-features[Feature Togglers]
+versions less than 1.9.  See https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#enable-disable-specific-features[Feature Togglers]
 for how to disable task support in Data Flow.
 

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/index.adoc
@@ -9,7 +9,7 @@ Sabby Anandan; Eric Bottard; Mark Fisher; Ilayaperumal Gopinathan; Gunnar Hiller
 :hide-uri-scheme:
 :docinfo: shared
 
-:spring-cloud-stream-docs: http://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/index.html
+:spring-cloud-stream-docs: https://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/index.html
 :github-code: https://github.com/spring-cloud/spring-cloud-dataflow-server-cloudfoundry
 
 ifdef::backend-html5[]

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/asciidoc/overview.adoc
@@ -4,14 +4,14 @@ Spring Cloud Data Flow is a cloud-native orchestration service for composable mi
 With Spring Cloud Data Flow, developers can create and orchestrate data pipelines for common use cases such as data ingest,
 real-time analytics, and data import/export.
 
-The Spring Cloud Data Flow architecture consists of a server that deploys http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#streams[Streams]
-and http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-task-overview[Tasks].
-Streams and Tasks are defined using a http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/_dsl_syntax.html[DSL]
-or visually through the browser based designer UI.  Streams and Tasks are based on http://cloud.spring.io/spring-cloud-stream/[Spring Cloud Stream]
-and http://cloud.spring.io/spring-cloud-task/[Spring Cloud Task] programming models respectively.
+The Spring Cloud Data Flow architecture consists of a server that deploys https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#streams[Streams]
+and https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#spring-cloud-task-overview[Tasks].
+Streams and Tasks are defined using a https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/_dsl_syntax.html[DSL]
+or visually through the browser based designer UI.  Streams and Tasks are based on https://cloud.spring.io/spring-cloud-stream/[Spring Cloud Stream]
+and https://cloud.spring.io/spring-cloud-task/[Spring Cloud Task] programming models respectively.
 
 For more details about the core architecture components and the supported features, please review Spring Cloud Data Flow's
-http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/[core reference guide].
+https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/[core reference guide].
 There're several https://github.com/spring-cloud/spring-cloud-dataflow-samples[samples] available for reference.
 
 [[spring-cloud-stream-overview]]
@@ -22,15 +22,15 @@ to message brokers. It provides opinionated configuration of middleware from sev
 persistent publish-subscribe semantics, consumer groups, and partitions.
 
 For more details about the core framework components and the supported features, please review Spring Cloud Stream's
-http://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/[reference guide].
+https://docs.spring.io/spring-cloud-stream/docs/{scst-core-version}/reference/htmlsingle/[reference guide].
 
-There's a rich ecosystem of Spring Cloud Stream http://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle[Application-Starters]
+There's a rich ecosystem of Spring Cloud Stream https://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle[Application-Starters]
 that can be used either as standalone microservice applications or in Spring Cloud Data Flow. For convenience, we have
-generated RabbitMQ and Apache Kafka variants of these application-starters that are available for use from http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[Maven Repo]
+generated RabbitMQ and Apache Kafka variants of these application-starters that are available for use from https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/[Maven Repo]
 and https://hub.docker.com/r/springcloudstream/[Docker Hub] as maven artifacts and docker images, respectively.
 
 Do you have a requirement to develop custom applications? No problem. Refer to this guide to create
-http://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle/#_creating_custom_artifacts[custom stream applications].
+https://docs.spring.io/spring-cloud-stream-app-starters/docs/{scst-starters-core-version}/reference/htmlsingle/#_creating_custom_artifacts[custom stream applications].
 There're several https://github.com/spring-cloud/spring-cloud-stream-samples[samples] available for reference.
 
 [[spring-cloud-task-overview]]
@@ -40,9 +40,9 @@ Spring Cloud Task makes it easy to create short-lived microservices. We provide 
 processes to be executed on demand in a production environment.
 
 For more details about the core framework components and the supported features, please review Spring Cloud Task's
-http://docs.spring.io/spring-cloud-task/docs/{sct-core-version}/reference/htmlsingle/[reference guide].
+https://docs.spring.io/spring-cloud-task/docs/{sct-core-version}/reference/htmlsingle/[reference guide].
 
-There's a rich ecosystem of Spring Cloud Task http://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[Application-Starters]
+There's a rich ecosystem of Spring Cloud Task https://docs.spring.io/spring-cloud-task-app-starters/docs/{sct-starters-core-version}/reference/htmlsingle[Application-Starters]
 that can be used either as standalone microservice applications or in Spring Cloud Data Flow. For convenience, the generated
-application-starters are available for use from http://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/[Maven Repo].
+application-starters are available for use from https://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/[Maven Repo].
 There are several https://github.com/spring-cloud/spring-cloud-task/tree/master/spring-cloud-task-samples[samples] available for reference.

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-dataflow-server-cloudfoundry-docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://dataflow-server.cfapps.io (ReadTimeoutException) with 2 occurrences migrated to:  
  https://dataflow-server.cfapps.io ([https](https://dataflow-server.cfapps.io) result ReadTimeoutException).
* [ ] http://myhost.mydomain.com/my-path (UnknownHostException) with 1 occurrences migrated to:  
  https://myhost.mydomain.com/my-path ([https](https://myhost.mydomain.com/my-path) result UnknownHostException).
* [ ] http://dataflow-AxwwAhK-httptest-http.cfapps.io (404) with 1 occurrences migrated to:  
  https://dataflow-AxwwAhK-httptest-http.cfapps.io ([https](https://dataflow-AxwwAhK-httptest-http.cfapps.io) result 404).
* [ ] http://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html ([https](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/security/oauth2/resource/AuthoritiesExtractor.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-skipper/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-skipper/ ([https](https://cloud.spring.io/spring-cloud-skipper/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-stream-app-starters/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-stream-app-starters/ ([https](https://cloud.spring.io/spring-cloud-stream-app-starters/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-stream/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-stream/ ([https](https://cloud.spring.io/spring-cloud-stream/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-task/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-task/ ([https](https://cloud.spring.io/spring-cloud-task/) result 200).
* [ ] http://docs.cloudfoundry.org/buildpacks/staticfile/index.html with 1 occurrences migrated to:  
  https://docs.cloudfoundry.org/buildpacks/staticfile/index.html ([https](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/ with 11 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/ ([https](https://docs.spring.io/spring-cloud-dataflow/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-stream-app-starters/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream-app-starters/docs/ ([https](https://docs.spring.io/spring-cloud-stream-app-starters/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-stream/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream/docs/ ([https](https://docs.spring.io/spring-cloud-stream/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-task-app-starters/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-task-app-starters/docs/ ([https](https://docs.spring.io/spring-cloud-task-app-starters/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-task/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-task/docs/ ([https](https://docs.spring.io/spring-cloud-task/docs/) result 200).
* [ ] http://pivotaljourney.blogspot.com/2016/05/connecting-gui-tool-to-mysql-service-in.html with 1 occurrences migrated to:  
  https://pivotaljourney.blogspot.com/2016/05/connecting-gui-tool-to-mysql-service-in.html ([https](https://pivotaljourney.blogspot.com/2016/05/connecting-gui-tool-to-mysql-service-in.html) result 200).
* [ ] http://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/ with 2 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/ ([https](https://repo.spring.io/libs-snapshot/org/springframework/cloud/stream/app/) result 200).
* [ ] http://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/ ([https](https://repo.spring.io/libs-snapshot/org/springframework/cloud/task/app/) result 200).
* [ ] http://stackoverflow.com with 1 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://stackoverflow.com/tags/spring-cloud-dataflow with 1 occurrences migrated to:  
  https://stackoverflow.com/tags/spring-cloud-dataflow ([https](https://stackoverflow.com/tags/spring-cloud-dataflow) result 200).
* [ ] http://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry with 2 occurrences migrated to:  
  https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry ([https](https://waffle.io/spring-cloud/spring-cloud-dataflow-server-cloudfoundry) result 200).
* [ ] http://bit.ly/Celsius-SR1-stream-applications-rabbit-maven with 1 occurrences migrated to:  
  https://bit.ly/Celsius-SR1-stream-applications-rabbit-maven ([https](https://bit.ly/Celsius-SR1-stream-applications-rabbit-maven) result 301).
* [ ] http://bit.ly/Clark-GA-task-applications-maven with 1 occurrences migrated to:  
  https://bit.ly/Clark-GA-task-applications-maven ([https](https://bit.ly/Clark-GA-task-applications-maven) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.pivotal.io/scdf/ with 1 occurrences migrated to:  
  https://docs.pivotal.io/scdf/ ([https](https://docs.pivotal.io/scdf/) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://repo.spring.io/ with 3 occurrences migrated to:  
  https://repo.spring.io/ ([https](https://repo.spring.io/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:9999/me with 1 occurrences
* http://127.0.0.1:9999/oauth/authorize with 1 occurrences
* http://127.0.0.1:9999/oauth/token with 1 occurrences
* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost:8761/eureka/ with 1 occurrences
* http://localhost:8888 with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences